### PR TITLE
Add The Ledger — financial dashboard with DynamoDB persistence

### DIFF
--- a/app/cdk/lib/vike-stack.ts
+++ b/app/cdk/lib/vike-stack.ts
@@ -14,6 +14,7 @@ import * as nodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as origin from "aws-cdk-lib/aws-cloudfront-origins";
 import * as api from "aws-cdk-lib/aws-apigatewayv2";
 import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as route53 from "aws-cdk-lib/aws-route53";
 import * as targets from "aws-cdk-lib/aws-route53-targets";
 import { existsSync } from "node:fs";
@@ -50,6 +51,22 @@ export class VikeStack extends cdk.Stack {
       ? Array.from(new Set([siteDomainName, domainName!].filter(Boolean)))
       : undefined;
 
+    // DynamoDB table for ledger data storage
+    // PK: userId (e.g. "ashton"), SK: dataKey (e.g. "ledger#state")
+    const ledgerTable = new dynamodb.Table(this, "LedgerTable", {
+      partitionKey: { name: "userId", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "dataKey", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    });
+
+    new ssm.StringParameter(this, "LedgerTableNameParameter", {
+      parameterName: `/${this.stackName}/ledger/table-name`,
+      stringValue: ledgerTable.tableName,
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
     const bucket = new s3.Bucket(this, "StaticAssetsBucket", {
       /**
        * The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
@@ -78,6 +95,7 @@ export class VikeStack extends cdk.Stack {
       depsLockFilePath: findBunLockFile(),
       environment: {
         NODE_ENV: "production",
+        LEDGER_TABLE_NAME: ledgerTable.tableName,
       },
       bundling: {
         banner,
@@ -96,6 +114,8 @@ export class VikeStack extends cdk.Stack {
       logRetention: logs.RetentionDays.THREE_DAYS,
       tracing: lambda.Tracing.ACTIVE,
     });
+
+    ledgerTable.grantReadWriteData(fn);
 
     const integration = new HttpLambdaIntegration("RequestHandlerIntegration", fn, {
       payloadFormatVersion: api.PayloadFormatVersion.VERSION_2_0,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1032.0",
+        "@aws-sdk/util-dynamodb": "^3.996.2",
         "@hono/node-server": "^1.19.5",
         "@sentry/react": "^10.17.0",
         "@ts-rest/core": "^3.52.1",
@@ -96,6 +98,675 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1032.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1032.0.tgz",
+      "integrity": "sha512-kkXiZBNdWCQAg/8opqAu10TxzdpqMkcGrNAT2ScdfWhCpzYZ2pmSpP8W7BOlA32jYIWnYrEdb808UZsNWYBPAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/credential-provider-node": "^3.972.32",
+        "@aws-sdk/dynamodb-codec": "^3.973.1",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.11",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.17",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.1.tgz",
+      "integrity": "sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.18",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.27.tgz",
+      "integrity": "sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.29.tgz",
+      "integrity": "sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.31.tgz",
+      "integrity": "sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/credential-provider-env": "^3.972.27",
+        "@aws-sdk/credential-provider-http": "^3.972.29",
+        "@aws-sdk/credential-provider-login": "^3.972.31",
+        "@aws-sdk/credential-provider-process": "^3.972.27",
+        "@aws-sdk/credential-provider-sso": "^3.972.31",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.31.tgz",
+      "integrity": "sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.32.tgz",
+      "integrity": "sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.27",
+        "@aws-sdk/credential-provider-http": "^3.972.29",
+        "@aws-sdk/credential-provider-ini": "^3.972.31",
+        "@aws-sdk/credential-provider-process": "^3.972.27",
+        "@aws-sdk/credential-provider-sso": "^3.972.31",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.27.tgz",
+      "integrity": "sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.31.tgz",
+      "integrity": "sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/token-providers": "3.1032.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.31.tgz",
+      "integrity": "sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.1.tgz",
+      "integrity": "sha512-BuxJyHW+fnuGLFZ84z5txzlfKXLVbf3hmWH4wQ9q5a/P6O5slNg6j2eUE2kQMYWt3A3PheUR4tgRBUC7j9i/nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@smithy/core": "^3.23.15",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.5.tgz",
+      "integrity": "sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.11.tgz",
+      "integrity": "sha512-vXARCZVFQHdsd6qPPZyC/hh+5x2XsCYKqUQDCqnUlpGpChMpDojOOacQWdLJ+FFXKN8X3cmLOGrtgx/zysCKqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.31.tgz",
+      "integrity": "sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.21.tgz",
+      "integrity": "sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.17",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
+      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1032.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1032.0.tgz",
+      "integrity": "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.2.tgz",
+      "integrity": "sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1003.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
+      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.17.tgz",
+      "integrity": "sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1485,6 +2156,587 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
+      "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.15",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
+      "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
+      "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
+      "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
+      "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
+      "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
+      "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
+      "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
+      "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.52",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
+      "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
+      "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
+      "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
+      "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
+      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
@@ -2609,6 +3861,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -3017,6 +4275,41 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fdir": {
@@ -3640,6 +4933,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3745,6 +5047,12 @@
         "npm": ">= 10"
       }
     },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3782,6 +5090,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -4213,6 +5536,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
@@ -4395,6 +5730,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.6",

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,8 @@
     "cdk": "cdk"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1032.0",
+    "@aws-sdk/util-dynamodb": "^3.996.2",
     "@hono/node-server": "^1.19.5",
     "@sentry/react": "^10.17.0",
     "@ts-rest/core": "^3.52.1",

--- a/app/pages/ledger/+Head.tsx
+++ b/app/pages/ledger/+Head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Old+Standard+TT:ital,wght@0,400;0,700;1,400&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap"
+        rel="stylesheet"
+      />
+    </>
+  );
+}

--- a/app/pages/ledger/+Page.tsx
+++ b/app/pages/ledger/+Page.tsx
@@ -1,0 +1,302 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ComponentType, Dispatch, SetStateAction } from "react";
+import {
+  ASHTON_PERSONAL, ASSETS, BUSINESS, DEBTS, INCOME, IOUS, JOINT_EXPENSES,
+  MARIA_PERSONAL, PENSIONS, SCENARIOS, SETTINGS, TAX, fx,
+} from "./data.js";
+import type {
+  Asset, BizCost, Debt, Expense, Income, Iou, PensionAccount, Scenario, SplitMode, TaxRates,
+} from "./data.js";
+import type { Derived, LedgerState } from "./state.js";
+import { useLedgerSync } from "./useLedgerSync.js";
+import type { LedgerStatePayload } from "../../ts-rest/contract.js";
+import { Dashboard } from "./screens/Dashboard.js";
+import { Flow } from "./screens/Flow.js";
+import { Runway } from "./screens/Runway.js";
+import { Inputs } from "./screens/Inputs.js";
+import { Retirement } from "./screens/Retirement.js";
+
+type RouteId = "dashboard" | "flow" | "runway" | "retirement" | "inputs";
+
+interface RouteDef {
+  id: RouteId;
+  label: string;
+  no: "I" | "II" | "III" | "IV" | "V";
+  component: ComponentType<{ state: LedgerState; d: Derived }>;
+}
+
+const ROUTES: RouteDef[] = [
+  { id: "dashboard",  label: "Dashboard",  no: "I",   component: Dashboard },
+  { id: "flow",       label: "Money flow", no: "II",  component: Flow },
+  { id: "runway",     label: "Runway",     no: "III", component: Runway },
+  { id: "retirement", label: "Retirement", no: "V",   component: Retirement },
+  { id: "inputs",     label: "Inputs",     no: "IV",  component: Inputs },
+];
+
+import type { SyncStatus } from "./useLedgerSync.js";
+
+function SyncBadge({ status, lastSaved }: { status: SyncStatus; lastSaved: string | null }) {
+  const dot: Record<SyncStatus, { label: string; color: string }> = {
+    loading: { label: "loading…",  color: "var(--ink-3)" },
+    idle:    { label: lastSaved ? `saved ${new Date(lastSaved).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}` : "local only", color: "var(--ink-4)" },
+    saving:  { label: "saving…",   color: "var(--ochre)" },
+    saved:   { label: "saved",     color: "var(--moss)" },
+    error:   { label: "sync error", color: "var(--crimson)" },
+  };
+  const { label, color } = dot[status];
+  return (
+    <div style={{ marginTop: 10, display: "flex", alignItems: "center", gap: 5, fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.1em", color }}>
+      <span style={{ width: 5, height: 5, borderRadius: "50%", background: color, display: "inline-block", flexShrink: 0 }} />
+      {label.toUpperCase()}
+    </div>
+  );
+}
+
+function readLocal<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  const v = localStorage.getItem(key);
+  return (v as unknown as T) ?? fallback;
+}
+
+export default function LedgerPage() {
+  const [route, setRoute] = useState<RouteId>(() => readLocal<RouteId>("ledger.route", "dashboard"));
+  const [income, setIncome] = useState<Income>(INCOME);
+  const [joint, setJoint] = useState<Expense[]>(JOINT_EXPENSES);
+  const [ashtonP, setAshtonP] = useState<Expense[]>(ASHTON_PERSONAL);
+  const [mariaP, setMariaP] = useState<Expense[]>(MARIA_PERSONAL);
+  const [assets, setAssets] = useState<Asset[]>(ASSETS);
+  const [debts, setDebts] = useState<Debt[]>(DEBTS);
+  const [ious, setIous] = useState<Iou[]>(IOUS);
+  const [bizCosts, setBizCosts] = useState<BizCost[]>(BUSINESS.costs);
+  const [bizRevenue, setBizRevenue] = useState<number>(BUSINESS.monthlyRevenue);
+  const [splitMode, setSplitMode] = useState<SplitMode>(SETTINGS.splitMode);
+  const [scenarios, setScenarios] = useState<Scenario[]>(SCENARIOS);
+  const [tax, setTax] = useState<TaxRates>(TAX);
+  const [dashView, setDashView] = useState<"joint" | "ashton" | "partner">(
+    () => readLocal<"joint" | "ashton" | "partner">("ledger.dashView", "joint")
+  );
+  const [amtPeriod, setAmtPeriod] = useState<"monthly" | "annual">(
+    () => readLocal<"monthly" | "annual">("ledger.amtPeriod", "monthly")
+  );
+  const [pensions, setPensions] = useState<PensionAccount[]>(PENSIONS);
+
+  useEffect(() => { if (typeof window !== "undefined") localStorage.setItem("ledger.route", route); }, [route]);
+  useEffect(() => { if (typeof window !== "undefined") localStorage.setItem("ledger.dashView", dashView); }, [dashView]);
+  useEffect(() => { if (typeof window !== "undefined") localStorage.setItem("ledger.amtPeriod", amtPeriod); }, [amtPeriod]);
+
+  // Serialisable payload — everything that lives in DynamoDB (UI prefs stay in localStorage)
+  const syncPayload = useMemo<LedgerStatePayload>(() => ({
+    income: income as LedgerStatePayload["income"],
+    joint, ashtonP, mariaP, assets, debts, ious,
+    bizCosts, bizRevenue,
+    splitMode,
+    tax: tax as LedgerStatePayload["tax"],
+    scenarios, pensions,
+  }), [income, joint, ashtonP, mariaP, assets, debts, ious, bizCosts, bizRevenue, splitMode, tax, scenarios, pensions]);
+
+  // Apply loaded state from DynamoDB
+  const onLoad = useCallback((s: LedgerStatePayload) => {
+    setIncome(s.income as Income);
+    setJoint(s.joint as Expense[]);
+    setAshtonP(s.ashtonP as Expense[]);
+    setMariaP(s.mariaP as Expense[]);
+    setAssets(s.assets as Asset[]);
+    setDebts(s.debts as Debt[]);
+    setIous(s.ious as Iou[]);
+    setBizCosts(s.bizCosts as BizCost[]);
+    setBizRevenue(s.bizRevenue);
+    setSplitMode(s.splitMode as SplitMode);
+    setTax(s.tax as TaxRates);
+    setScenarios(s.scenarios as Scenario[]);
+    if (s.pensions) setPensions(s.pensions as PensionAccount[]);
+  }, []);
+
+  const { status: syncStatus, lastSaved } = useLedgerSync(syncPayload, onLoad);
+
+  const state: LedgerState = {
+    income, setIncome,
+    joint, setJoint,
+    ashtonP, setAshtonP,
+    mariaP, setMariaP,
+    assets, setAssets,
+    debts, setDebts,
+    ious, setIous,
+    bizCosts, setBizCosts,
+    bizRevenue, setBizRevenue,
+    splitMode, setSplitMode,
+    tax, setTax,
+    scenarios, setScenarios,
+    dashView, setDashView: setDashView as Dispatch<SetStateAction<"joint" | "ashton" | "partner">>,
+    amtPeriod, setAmtPeriod,
+    pensions, setPensions,
+  };
+
+  const derived: Derived = useMemo(() => {
+    const jointTotal = joint.reduce((s, x) => s + x.amt, 0);
+    const aPersonal = ashtonP.reduce((s, x) => s + x.amt, 0);
+    const mPersonal = mariaP.reduce((s, x) => s + x.amt, 0);
+    const aDividendNet = income.ashton.dividend * (1 - tax.dividendTaxRate);
+    const aIncome = income.ashton.salary + aDividendNet;
+    const mGrossSalary = income.partner.gross || income.partner.total;
+    const mIncome = mGrossSalary * (1 - tax.mariaTaxRate);
+    const aGross = income.ashton.gross || aIncome;
+    const mGross = mGrossSalary;
+    const bizNetLocal = bizRevenue - bizCosts.reduce((s, c) => s + c.amt, 0);
+    let aShare: number;
+    if (splitMode === "fifty") aShare = 0.5;
+    else if (splitMode === "gross") aShare = aGross / (aGross + mGross);
+    else if (splitMode === "bizNet") {
+      const aBizContribution = aIncome + Math.max(0, bizNetLocal);
+      aShare = aBizContribution / (aBizContribution + mIncome);
+    }
+    else if (splitMode === "custom") aShare = SETTINGS.ashtonPortionCustom || 0.6;
+    else aShare = aIncome / (aIncome + mIncome);
+    const mShare = 1 - aShare;
+    const aBurn = aPersonal + jointTotal * aShare;
+    const mBurn = mPersonal + jointTotal * mShare;
+    const hhBurn = jointTotal + aPersonal + mPersonal;
+    const hhIncome = aIncome + mIncome;
+    const hhSaving = hhIncome - hhBurn;
+
+    const personalAssets = assets.filter(a => a.scope === "personal").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const personalAssetsA = assets.filter(a => a.scope === "personal" && a.owner === "ashton").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const personalAssetsM = assets.filter(a => a.scope === "personal" && a.owner === "partner").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const businessAssets = assets.filter(a => a.scope === "business").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const liquidAssets = assets.filter(a => a.type === "cash" || a.type === "hysa" || a.type === "receivable").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const liquidA = assets.filter(a => (a.type === "cash" || a.type === "hysa") && a.owner === "ashton").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const liquidM = assets.filter(a => (a.type === "cash" || a.type === "hysa") && a.owner === "partner").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const brokerageAssets = assets.filter(a => a.type === "brokerage").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const pensionAssets = assets.filter(a => a.type === "pension").reduce((s, a) => s + a.bal * fx[a.cur], 0);
+    const totalAssets = personalAssets + businessAssets;
+    const debtA = debts.filter(dd => dd.owner === "ashton").reduce((s, dd) => s + dd.bal * fx[dd.cur], 0);
+    const debtM = debts.filter(dd => dd.owner === "partner").reduce((s, dd) => s + dd.bal * fx[dd.cur], 0);
+    const totalDebt = debts.reduce((s, dd) => s + dd.bal * fx[dd.cur], 0);
+    const iouIncoming = ious.filter(i => i.direction === "incoming").reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
+    const iouOutgoing = ious.filter(i => i.direction === "outgoing").reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
+    const iouNet = iouIncoming - iouOutgoing;
+    const netWorth = totalAssets - totalDebt + iouNet;
+    const netWorthA = personalAssetsA + businessAssets - debtA + iouNet;
+    const netWorthM = personalAssetsM - debtM;
+
+    const bizCostTotal = bizCosts.reduce((s, c) => s + c.amt, 0);
+    const bizNetFinal = bizRevenue - bizCostTotal;
+
+    return {
+      jointTotal, aPersonal, mPersonal, aIncome, mIncome, aGross, mGross, aShare, mShare, aBurn, mBurn,
+      hhBurn, hhIncome, hhSaving,
+      personalAssets, personalAssetsA, personalAssetsM, businessAssets,
+      liquidAssets, liquidA, liquidM, brokerageAssets, pensionAssets,
+      totalAssets, totalDebt, debtA, debtM, netWorth, netWorthA, netWorthM,
+      bizCostTotal, bizNet: bizNetFinal,
+      iouIncoming, iouOutgoing, iouNet,
+    };
+  }, [income, joint, ashtonP, mariaP, assets, debts, ious, bizCosts, bizRevenue, splitMode, tax]);
+
+  const currentRoute = ROUTES.find(r => r.id === route) || ROUTES[0];
+  const Active = currentRoute.component;
+
+  const mult = amtPeriod === "annual" ? 12 : 1;
+  const periodLabel = amtPeriod === "annual" ? "/yr" : "/mo";
+
+  return (
+    <div className="ledger-root">
+      <div className="app">
+        <aside className="sidebar">
+          <div className="masthead">
+            <div className="crest">ashtonspina.com /vault</div>
+            <h1>The Ledger</h1>
+            <div className="edition">
+              <span>APR 2026</span>
+              <span>№ I of XII</span>
+            </div>
+          </div>
+
+          <nav className="nav">
+            <div className="nav-section-label">Views</div>
+            <ul>
+              {ROUTES.filter(r => r.id !== "inputs").map(r => (
+                <li key={r.id} className={r.id === route ? "active" : ""}
+                  onClick={() => setRoute(r.id)}>
+                  <span className="nav-label">{r.label}</span>
+                  <span className="nav-num">{r.no}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="nav-section-label" style={{ marginTop: 20 }}>Edit</div>
+            <ul>
+              <li className={route === "inputs" ? "active" : ""}
+                onClick={() => setRoute("inputs")}>
+                <span className="nav-label">Inputs</span>
+                <span className="nav-num">IV</span>
+              </li>
+            </ul>
+          </nav>
+
+          <div>
+            <div className="nav-section-label">April, at a glance</div>
+            <div className="flex-col gap-sm" style={{ fontSize: 12.5 }}>
+              <div className="flex-between">
+                <span className="italic">Household income</span>
+                <span className="mono">
+                  €{Math.round(derived.hhIncome * mult).toLocaleString()}
+                  <span style={{ fontSize: 9, color: "var(--ink-4)", fontFamily: "var(--mono)", marginLeft: 2 }}>{periodLabel}</span>
+                </span>
+              </div>
+              <div className="flex-between">
+                <span className="italic">Combined burn</span>
+                <span className="mono">
+                  €{Math.round(derived.hhBurn * mult).toLocaleString()}
+                  <span style={{ fontSize: 9, color: "var(--ink-4)", fontFamily: "var(--mono)", marginLeft: 2 }}>{periodLabel}</span>
+                </span>
+              </div>
+              <div className="flex-between">
+                <span className="italic">Net saving</span>
+                <span className={`mono ${derived.hhSaving > 0 ? "pos" : "neg"}`}>
+                  €{Math.round(derived.hhSaving * mult).toLocaleString()}
+                  <span style={{ fontSize: 9, color: "var(--ink-4)", fontFamily: "var(--mono)", marginLeft: 2 }}>{periodLabel}</span>
+                </span>
+              </div>
+              <hr className="rule" style={{ margin: "6px 0" }} />
+              <div className="flex-between"><span className="italic">Net worth</span><span className="mono">€{Math.round(derived.netWorth).toLocaleString()}</span></div>
+              <div className="flex-between mt-sm" style={{ fontSize: 11 }}>
+                <span className="italic">Show as</span>
+                <span style={{ display: "flex", gap: 0, border: "1px solid var(--rule-soft)", fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.1em" }}>
+                  <button onClick={() => setAmtPeriod("monthly")} style={{ padding: "2px 7px", background: amtPeriod === "monthly" ? "var(--ink)" : "transparent", color: amtPeriod === "monthly" ? "var(--paper)" : "var(--ink-3)", border: "none" }}>MO</button>
+                  <button onClick={() => setAmtPeriod("annual")} style={{ padding: "2px 7px", background: amtPeriod === "annual" ? "var(--ink)" : "transparent", color: amtPeriod === "annual" ? "var(--paper)" : "var(--ink-3)", border: "none" }}>YR</button>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="footer-note">
+            &ldquo;Annual income twenty pounds, annual expenditure nineteen nineteen and six, result happiness.&rdquo;
+            <div className="smallcaps mt-sm">— Mr. Micawber</div>
+            <SyncBadge status={syncStatus} lastSaved={lastSaved} />
+          </div>
+        </aside>
+
+        <main className="main" key={route}>
+          {/* Shown only on tablet/mobile — replaces sidebar nav */}
+          <div className="mobile-header">
+            <div className="mobile-header-bar">
+              <div className="mobile-title">The Ledger</div>
+              <div className="mobile-edition">APR 2026</div>
+            </div>
+            <div className="mobile-tabs">
+              {ROUTES.filter(r => r.id !== "inputs").map(r => (
+                <button key={r.id} className={r.id === route ? "active" : ""}
+                  onClick={() => setRoute(r.id)}>
+                  {r.label}
+                </button>
+              ))}
+              <button className={route === "inputs" ? "active" : ""} onClick={() => setRoute("inputs")}>
+                Edit
+              </button>
+            </div>
+          </div>
+          <Active state={state} d={derived} />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/app/pages/ledger/+config.ts
+++ b/app/pages/ledger/+config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "vike/types";
+import Layout from "./LedgerLayout.js";
+
+export default {
+  title: "The Ledger — Household & Holdings",
+  description: "Editorial budget dashboard — household, business, and runway on one page.",
+  Layout,
+  ssr: false,
+} satisfies Config;

--- a/app/pages/ledger/LedgerLayout.tsx
+++ b/app/pages/ledger/LedgerLayout.tsx
@@ -1,0 +1,11 @@
+import "./styles.css";
+import { useEffect, type ReactNode } from "react";
+
+export default function LedgerLayout({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    document.body.classList.add("ledger-active");
+    return () => { document.body.classList.remove("ledger-active"); };
+  }, []);
+
+  return <div className="ledger-layout-escape">{children}</div>;
+}

--- a/app/pages/ledger/charts.tsx
+++ b/app/pages/ledger/charts.tsx
@@ -1,0 +1,151 @@
+interface Point { [k: string]: number | string; }
+
+export function AreaChart({ data, width = 800, height = 220, x = "m", y = "v", style = "engraved" }:
+  { data: Point[]; width?: number; height?: number; x?: string; y?: string; style?: "engraved" | "solid" }) {
+  const pad = { l: 44, r: 12, t: 14, b: 22 };
+  const W = width - pad.l - pad.r;
+  const H = height - pad.t - pad.b;
+  const vals = data.map(d => d[y] as number);
+  const ymin = Math.min(...vals) * 0.95;
+  const ymax = Math.max(...vals) * 1.05;
+  const xStep = W / (data.length - 1);
+  const yScale = (v: number) => pad.t + H - ((v - ymin) / (ymax - ymin)) * H;
+  const xScale = (i: number) => pad.l + i * xStep;
+
+  const pts = data.map((d, i) => [xScale(i), yScale(d[y] as number)] as [number, number]);
+  const line = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p[0]},${p[1]}`).join(" ");
+  const area = line + ` L${pts[pts.length - 1][0]},${pad.t + H} L${pts[0][0]},${pad.t + H} Z`;
+
+  const ticks = 4;
+  const yTicks = Array.from({ length: ticks + 1 }, (_, i) => ymin + (ymax - ymin) * i / ticks);
+
+  return (
+    <svg className="chart" viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+      {yTicks.map((t, i) => (
+        <g key={i}>
+          <line x1={pad.l} x2={width - pad.r} y1={yScale(t)} y2={yScale(t)} className="grid-line" />
+          <text x={pad.l - 6} y={yScale(t) + 3} textAnchor="end">{Math.round(t / 1000)}k</text>
+        </g>
+      ))}
+      {style === "engraved" && (
+        <defs>
+          <pattern id="hatch" patternUnits="userSpaceOnUse" width="5" height="5" patternTransform="rotate(45)">
+            <line x1="0" y1="0" x2="0" y2="5" stroke="var(--rust)" strokeWidth="0.6" opacity="0.5" />
+          </pattern>
+        </defs>
+      )}
+      <path d={area} fill={style === "engraved" ? "url(#hatch)" : "var(--rust-soft)"} />
+      <path d={line} className="line" />
+
+      {data.map((d, i) => (
+        i % 3 === 0 || i === data.length - 1 ? (
+          <text key={i} x={xScale(i)} y={height - 6} textAnchor="middle">{(d[x] as string).split(" ")[0]}</text>
+        ) : null
+      ))}
+
+      <circle cx={pts[pts.length - 1][0]} cy={pts[pts.length - 1][1]} r="3" className="marker" />
+      <text x={pts[pts.length - 1][0] + 6} y={pts[pts.length - 1][1] - 4} className="mono" style={{ fontSize: 10, fill: "var(--ink)" }}>
+        €{Math.round(vals[vals.length - 1] / 1000)}k
+      </text>
+    </svg>
+  );
+}
+
+export function Sparkline({ data, width = 140, height = 30, tone = "ink" }:
+  { data: number[]; width?: number; height?: number; tone?: "ink" | "rust" | "moss" }) {
+  const vals = data;
+  const min = Math.min(...vals), max = Math.max(...vals);
+  const pts = vals.map((v, i) => [
+    (i / (vals.length - 1)) * width,
+    height - ((v - min) / (max - min || 1)) * (height - 4) - 2,
+  ] as [number, number]);
+  const d = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(" ");
+  const stroke = tone === "rust" ? "var(--rust)" : tone === "moss" ? "var(--moss)" : "var(--ink)";
+  return (
+    <svg width={width} height={height} style={{ display: "block" }}>
+      <path d={d} fill="none" stroke={stroke} strokeWidth="1.2" />
+      <circle cx={pts[pts.length - 1][0]} cy={pts[pts.length - 1][1]} r="2" fill={stroke} />
+    </svg>
+  );
+}
+
+export function Donut({ segs, size = 140, stroke = 26 }: { segs: { value: number; color: string; label?: string }[]; size?: number; stroke?: number }) {
+  const r = size / 2 - stroke / 2;
+  const C = 2 * Math.PI * r;
+  let offset = 0;
+  const total = segs.reduce((s, x) => s + x.value, 0);
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--paper-3)" strokeWidth={stroke} />
+      {segs.map((s, i) => {
+        const len = total > 0 ? (s.value / total) * C : 0;
+        const el = <circle
+          key={i} cx={size / 2} cy={size / 2} r={r} fill="none"
+          stroke={s.color} strokeWidth={stroke}
+          strokeDasharray={`${len} ${C - len}`}
+          strokeDashoffset={-offset}
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />;
+        offset += len;
+        return el;
+      })}
+    </svg>
+  );
+}
+
+export function DepletionChart({ width = 800, height = 220, months = 42, monthlyBurn = 5200, startValue, targetFloor = 15000 }:
+  { width?: number; height?: number; months?: number; monthlyBurn?: number; startValue: number; targetFloor?: number }) {
+  const pad = { l: 44, r: 60, t: 14, b: 28 };
+  const W = width - pad.l - pad.r;
+  const H = height - pad.t - pad.b;
+
+  const pts: { i: number; v: number }[] = [];
+  let v = startValue;
+  for (let i = 0; i <= months; i++) {
+    pts.push({ i, v });
+    v = Math.max(0, v - monthlyBurn);
+    if (v <= 0) { pts.push({ i: i + 1, v: 0 }); break; }
+  }
+  const ymax = startValue * 1.08;
+  const xScale = (i: number) => pad.l + (i / months) * W;
+  const yScale = (v: number) => pad.t + H - (v / ymax) * H;
+
+  const line = pts.map((p, i) => `${i === 0 ? "M" : "L"}${xScale(p.i)},${yScale(p.v)}`).join(" ");
+  const area = line + ` L${xScale(pts[pts.length - 1].i)},${pad.t + H} L${pad.l},${pad.t + H} Z`;
+
+  const floorY = yScale(targetFloor);
+  const zeroAt = pts.find(p => p.v === 0);
+
+  const ticks = 4;
+  const yTicks = Array.from({ length: ticks + 1 }, (_, i) => (ymax / ticks) * i);
+
+  return (
+    <svg className="chart" viewBox={`0 0 ${width} ${height}`}>
+      {yTicks.map((t, i) => (
+        <g key={i}>
+          <line x1={pad.l} x2={width - pad.r} y1={yScale(t)} y2={yScale(t)} className="grid-line" />
+          <text x={pad.l - 6} y={yScale(t) + 3} textAnchor="end">€{Math.round(t / 1000)}k</text>
+        </g>
+      ))}
+      <path d={area} fill="var(--rust-soft)" />
+      <path d={line} className="line" />
+
+      <line x1={pad.l} x2={width - pad.r} y1={floorY} y2={floorY} stroke="var(--crimson)" strokeDasharray="4 3" strokeWidth="1" />
+      <text x={width - pad.r + 4} y={floorY + 3} style={{ fill: "var(--crimson)" }}>floor €{Math.round(targetFloor / 1000)}k</text>
+
+      {zeroAt && (
+        <>
+          <line x1={xScale(zeroAt.i)} x2={xScale(zeroAt.i)} y1={pad.t} y2={pad.t + H}
+                stroke="var(--ink)" strokeDasharray="2 3" />
+          <text x={xScale(zeroAt.i) + 4} y={pad.t + 12} style={{ fill: "var(--ink)", fontWeight: 600 }}>
+            Zero at month {zeroAt.i}
+          </text>
+        </>
+      )}
+
+      {[0, 6, 12, 18, 24, 30, 36].filter(m => m <= months).map(m => (
+        <text key={m} x={xScale(m)} y={height - 8} textAnchor="middle">M{m}</text>
+      ))}
+    </svg>
+  );
+}

--- a/app/pages/ledger/data.ts
+++ b/app/pages/ledger/data.ts
@@ -1,0 +1,365 @@
+/* Seed data + type definitions for the Ledger. */
+
+export const fx: Record<string, number> = { EUR: 1.0, USD: 0.91, GBP: 1.17, CAD: 0.68 };
+
+export const PEOPLE = {
+  ashton: { name: "Ashton", short: "AS" },
+  partner: { name: "Maria", short: "MA" },
+};
+
+export type CategoryKey =
+  | "housing" | "food" | "utilities" | "transit" | "media" | "health"
+  | "loans" | "savings" | "insurance" | "gifts" | "education" | "other";
+
+export const CATEGORIES: Record<string, { label: string; color: string }> = {
+  housing:   { label: "Housing",            color: "#1A1714" },
+  food:      { label: "Food",               color: "#8B5A3C" },
+  utilities: { label: "Utilities",          color: "#6B7458" },
+  transit:   { label: "Transit",            color: "#A68A5B" },
+  media:     { label: "Media & subs",       color: "#4A6B7E" },
+  health:    { label: "Health & body",      color: "#9B4D3A" },
+  loans:     { label: "Loan repayment",     color: "#3A4B5E" },
+  savings:   { label: "Savings & vacation", color: "#2D6154" },
+  insurance: { label: "Insurance",          color: "#7C6E8F" },
+  gifts:     { label: "Gifts & family",     color: "#8F6A4A" },
+  education: { label: "Education",          color: "#4B7C6E" },
+  other:     { label: "Other",              color: "#555" },
+};
+
+export interface TaxRates {
+  salaryTaxRate: number;
+  corpTaxRate: number;
+  dividendTaxRate: number;
+  mariaTaxRate: number;
+}
+
+export const TAX: TaxRates = {
+  salaryTaxRate: 0.242,
+  corpTaxRate: 0.20,
+  dividendTaxRate: 0.2625,
+  mariaTaxRate: 0.241,
+};
+
+export interface BizCost { label: string; amt: number; }
+
+export interface Business {
+  companyName: string;
+  monthlyRevenue: number;
+  yearlyRevenue: number;
+  grossSalary: number;
+  dividendMonthly: number;
+  costs: BizCost[];
+}
+
+export const BUSINESS: Business = {
+  companyName: "Ashton's Oy",
+  monthlyRevenue: 11100,
+  yearlyRevenue: 133200,
+  grossSalary: 5999.00,
+  dividendMonthly: 1737.29,
+  costs: [
+    { label: "YEL (pension)",          amt: 854.79 },
+    { label: "Cursor",                 amt:  40.00 },
+    { label: "Banking costs",          amt:  16.43 },
+    { label: "Accountant",             amt: 220.00 },
+    { label: "AWS",                    amt: 300.00 },
+    { label: "ChatGPT personal",       amt:  20.00 },
+    { label: "ChatGPT tokens",         amt:  40.00 },
+    { label: "Linear",                 amt:  35.26 },
+    { label: "Algolia",                amt:  40.00 },
+    { label: "Google Ads",             amt:  90.00 },
+    { label: "Google One",             amt:   9.99 },
+    { label: "Sentry",                 amt:  26.00 },
+    { label: "Ahrefs",                 amt:  26.99 },
+    { label: "EdenRed service fee",    amt:   6.00 },
+    { label: "EdenRed sports benefit", amt:  33.33 },
+    { label: "EdenRed lunch benefit",  amt:  60.00 },
+    { label: "Elisa internet",         amt:  78.00 },
+    { label: "Unemployment fund",      amt:  75.00 },
+  ],
+};
+
+export function deriveBiz(biz: { monthlyRevenue: number; costs: BizCost[]; grossSalary: number; dividendMonthly: number }, tax: TaxRates) {
+  const opCosts = biz.costs.reduce((s, c) => s + c.amt, 0);
+  const salaryTax = biz.grossSalary * tax.salaryTaxRate;
+  const netSalary = biz.grossSalary - salaryTax;
+  const preTaxProfit = biz.monthlyRevenue - opCosts - biz.grossSalary;
+  const corpTax = Math.max(0, preTaxProfit * tax.corpTaxRate);
+  const afterCorp = preTaxProfit - corpTax;
+  const dividendGross = biz.dividendMonthly;
+  const dividendTax = dividendGross * tax.dividendTaxRate;
+  const dividendNet = dividendGross - dividendTax;
+  const retained = afterCorp - dividendGross;
+  return { opCosts, salaryTax, netSalary, preTaxProfit, corpTax, afterCorp,
+           dividendGross, dividendTax, dividendNet, retained };
+}
+
+export interface Income {
+  ashton: { gross: number; salary: number; dividend: number; personalTax: number; total: number };
+  partner: { gross: number; salary: number; personalTax: number; total: number };
+}
+
+export const INCOME: Income = {
+  ashton:  { gross: 6283.29, salary: 4546.00, dividend: 1737.29, personalTax: 0, total: 6283.29 },
+  partner: { gross: 5540.00, salary: 4205.00, personalTax: 1335.00, total: 4205.00 },
+};
+
+export interface Expense { id?: string; label: string; amt: number; cat?: CategoryKey | string; }
+
+export const JOINT_EXPENSES: Expense[] = [
+  { id: "rent",    label: "Rent",            amt: 2074.00, cat: "housing" },
+  { id: "groc",    label: "Groceries",       amt: 1600.00, cat: "food" },
+  { id: "elec",    label: "Electricity",     amt:  120.00, cat: "utilities" },
+  { id: "net",     label: "Internet",        amt:   50.00, cat: "utilities" },
+  { id: "ins",     label: "Insurances",      amt:   20.00, cat: "insurance" },
+  { id: "fuel",    label: "Fuel",            amt:   70.00, cat: "transit" },
+  { id: "carm",    label: "Car maintenance", amt:   17.50, cat: "transit" },
+  { id: "dis",     label: "Disney+",         amt:   13.99, cat: "media" },
+  { id: "hbo",     label: "HBO Max",         amt:    5.00, cat: "media" },
+  { id: "prime",   label: "Amazon Prime",    amt:   10.00, cat: "media" },
+  { id: "appletv", label: "Apple TV",        amt:    8.00, cat: "media" },
+  { id: "netflix", label: "Netflix",         amt:   12.00, cat: "media" },
+];
+
+export const ASHTON_PERSONAL: Expense[] = [
+  { label: "Phone plan",            amt:  36.00, cat: "utilities" },
+  { label: "Medical costs",         amt:  56.00, cat: "health" },
+  { label: "Banking",               amt:   4.00, cat: "other" },
+  { label: "Hygiene products",      amt: 100.00, cat: "health" },
+  { label: "Gym membership",        amt:  63.00, cat: "health" },
+  { label: "YouTube Premium",       amt:  14.99, cat: "media" },
+  { label: "Yousician",             amt:  14.99, cat: "media" },
+  { label: "Greenpeace",            amt:  10.00, cat: "gifts" },
+  { label: "DuoCards",              amt:   3.33, cat: "education" },
+  { label: "Macrofactor",           amt:   6.16, cat: "health" },
+  { label: "Parcel",                amt:   0.41, cat: "other" },
+  { label: "Flighty",               amt:   4.19, cat: "other" },
+  { label: "Patreon",               amt:  18.84, cat: "media" },
+  { label: "Apple One",             amt:  20.95, cat: "media" },
+  { label: "AppleCare",             amt:  19.48, cat: "other" },
+  { label: "SCMP",                  amt:   4.99, cat: "media" },
+  { label: "Dreaming Spanish",      amt:   6.99, cat: "education" },
+  { label: "Helsinki AB transport", amt:  60.10, cat: "transit" },
+  { label: "DUO loan repayment",    amt:  20.92, cat: "loans" },
+  { label: "OSAP",                  amt:  65.89, cat: "loans" },
+  { label: "Vacation fund",         amt: 300.00, cat: "savings" },
+  { label: "Gifts",                 amt: 100.00, cat: "gifts" },
+  { label: "Domi full-time costs",  amt: 768.00, cat: "gifts" },
+  { label: "Google One",            amt:   8.33, cat: "media" },
+];
+
+export const MARIA_PERSONAL: Expense[] = [
+  { label: "Phone plans",           amt:  20.00, cat: "utilities" },
+  { label: "Parking",               amt:  98.00, cat: "transit" },
+  { label: "Car insurance",         amt:  90.00, cat: "insurance" },
+  { label: "Banking",               amt:   4.00, cat: "other" },
+  { label: "Beauty supplies",       amt: 100.00, cat: "health" },
+  { label: "Gym membership",        amt:  55.00, cat: "health" },
+  { label: "Phone payment",         amt:  36.00, cat: "other" },
+  { label: "Podme",                 amt:  11.99, cat: "media" },
+  { label: "Helsinki AB transport", amt:  61.00, cat: "transit" },
+  { label: "Student loan payments", amt: 225.00, cat: "loans" },
+  { label: "Vacation",              amt: 300.00, cat: "savings" },
+  { label: "Dentist",               amt: 300.00, cat: "health" },
+  { label: "Gifts",                 amt: 100.00, cat: "gifts" },
+  { label: "Work lunches",          amt: 100.00, cat: "food" },
+  { label: "DUO loan repayment",    amt:   6.00, cat: "loans" },
+  { label: "Union fee",             amt:  25.00, cat: "other" },
+];
+
+export type AssetType = "cash" | "hysa" | "brokerage" | "receivable" | "pension";
+export type AssetScope = "personal" | "business";
+export type AssetOwner = "ashton" | "partner";
+
+export interface Asset {
+  id: string;
+  label: string;
+  type: AssetType;
+  scope: AssetScope;
+  owner: AssetOwner;
+  cur: string;
+  bal: number;
+  apy: number | null;
+}
+
+export const ASSETS: Asset[] = [
+  { id: "bmo",           label: "BMO",                  type: "cash",      scope: "personal", owner: "ashton",  cur: "CAD", bal:  6500.00, apy: 0.000 },
+  { id: "op_personal",   label: "OP Personal",          type: "cash",      scope: "personal", owner: "ashton",  cur: "EUR", bal:  2500.00, apy: 0.000 },
+  { id: "lightyear_p",   label: "Lightyear — Personal", type: "brokerage", scope: "personal", owner: "ashton",  cur: "EUR", bal:     0.03, apy: null },
+  { id: "wise",          label: "Wise",                 type: "cash",      scope: "personal", owner: "ashton",  cur: "EUR", bal:   651.00, apy: 0.000 },
+  { id: "swiss_pension", label: "Swiss pension",        type: "pension",   scope: "personal", owner: "ashton",  cur: "EUR", bal: 30000.00, apy: null },
+  { id: "op_biz",        label: "OP Business",          type: "cash",      scope: "business", owner: "ashton",  cur: "EUR", bal: 10195.00, apy: 0.000 },
+  { id: "op_biz_invest", label: "OP Business — Invest", type: "brokerage", scope: "business", owner: "ashton",  cur: "EUR", bal:     0.00, apy: null },
+  { id: "lightyear_b",   label: "Lightyear — Business", type: "brokerage", scope: "business", owner: "ashton",  cur: "EUR", bal: 96034.00, apy: null },
+  { id: "op_maria",      label: "OP (Maria)",           type: "cash",      scope: "personal", owner: "partner", cur: "EUR", bal:  3200.00, apy: 0.000 },
+  { id: "nordea_maria",  label: "Nordea savings",       type: "hysa",      scope: "personal", owner: "partner", cur: "EUR", bal:  8400.00, apy: 0.025 },
+  { id: "varma_pension", label: "TyEL pension (est.)",  type: "pension",   scope: "personal", owner: "partner", cur: "EUR", bal: 14000.00, apy: null },
+];
+
+export interface Debt { id: string; label: string; owner: AssetOwner; bal: number; cur: string; rate: number; }
+
+export const DEBTS: Debt[] = [
+  { id: "osap",       label: "Canada-Ontario Student Loan (OSAP)", owner: "ashton",  bal:  9900.00, cur: "CAD", rate: 0.050 },
+  { id: "duo",        label: "DUO student loan",                   owner: "ashton",  bal:  5000.00, cur: "EUR", rate: 0.050 },
+  { id: "biz_loan",   label: "Business Loan",                      owner: "ashton",  bal:  2000.00, cur: "EUR", rate: 0.000 },
+  { id: "maria_duo",  label: "DUO (Maria)",                        owner: "partner", bal:  1800.00, cur: "EUR", rate: 0.028 },
+  { id: "maria_fi",   label: "Kela student loan",                  owner: "partner", bal: 12400.00, cur: "EUR", rate: 0.019 },
+];
+
+export interface IouEntry { d: string; label: string; amt: number; kind: "lent" | "borrowed" | "repaid" | "adjust"; }
+
+export interface Iou {
+  id: string;
+  counterparty: string;
+  direction: "incoming" | "outgoing";
+  cur: string;
+  principal: number;
+  paid: number;
+  note: string;
+  history: IouEntry[];
+}
+
+export const IOUS: Iou[] = [
+  { id: "bethany", counterparty: "Bethany", direction: "incoming", cur: "CAD",
+    principal: 44500.00, paid: 13120.00, note: "Rent apt + cat vet + Taylor/Shayna adjustments",
+    history: [
+      { d: "2023-09-01", label: "Rent apartment",    amt: 40000.00, kind: "lent" },
+      { d: "2023-11-12", label: "Cat vet bills",     amt:  4500.00, kind: "lent" },
+      { d: "2024-02-03", label: "Payment to Taylor", amt:  -120.00, kind: "adjust" },
+      { d: "2024-08-01", label: "Shayna repaid",     amt:  3000.00, kind: "repaid" },
+      { d: "2025-03-15", label: "Bethany repaid",    amt: 10000.00, kind: "repaid" },
+    ]
+  },
+];
+
+export type SplitMode = "gross" | "net" | "bizNet" | "fifty" | "custom";
+
+export const SETTINGS = {
+  splitMode: "net" as SplitMode,
+  ashtonPortionCustom: 0.60,
+  homeCurrency: "EUR",
+  runwayFloor: 5000,
+};
+
+export interface PensionAccount {
+  id: string;
+  label: string;
+  owner: "ashton" | "partner";
+  type: "YEL" | "TyEL" | "private" | "state";
+  cur: string;
+  currentBal: number;
+  monthlyContrib: number;
+  accrualRatePct: number;
+  projectedMonthlyAt65: number;
+  note: string;
+}
+
+export const PENSIONS: PensionAccount[] = [
+  {
+    id: "yel_ashton",
+    label: "YEL (Elo) — Ashton",
+    owner: "ashton",
+    type: "YEL",
+    cur: "EUR",
+    currentBal: 0,
+    monthlyContrib: 854.79,
+    accrualRatePct: 1.5,
+    projectedMonthlyAt65: 0,
+    note: "Finnish self-employed pension. YEL income set at ~€50k/yr. Vesting immediate.",
+  },
+  {
+    id: "swiss_pension_acc",
+    label: "Swiss pillar 2 — Ashton",
+    owner: "ashton",
+    type: "private",
+    cur: "EUR",
+    currentBal: 30000,
+    monthlyContrib: 0,
+    accrualRatePct: 0,
+    projectedMonthlyAt65: 0,
+    note: "Locked in Swiss pillar 2 from previous employment. Accessible at retirement.",
+  },
+  {
+    id: "tyel_maria",
+    label: "TyEL — Maria",
+    owner: "partner",
+    type: "TyEL",
+    cur: "EUR",
+    currentBal: 14000,
+    monthlyContrib: 0,
+    accrualRatePct: 1.5,
+    projectedMonthlyAt65: 0,
+    note: "Finnish earnings-related pension. Accrues 1.5% of annual earnings per year.",
+  },
+];
+
+export interface ScenarioExpense { id?: string; label: string; amt: number; cat?: string; }
+
+export interface Scenario {
+  id: string;
+  name: string;
+  note: string;
+  partnerWorking: boolean;
+  includeInvest: boolean;
+  includeBusiness: boolean;
+  // Per-scenario snapshots of expenses — edit independently of live inputs
+  joint: ScenarioExpense[];
+  ashtonP: ScenarioExpense[];
+  mariaP: ScenarioExpense[];
+}
+
+function snap(expenses: Expense[]): ScenarioExpense[] {
+  return expenses.map(e => ({ id: e.id, label: e.label, amt: e.amt, cat: e.cat }));
+}
+
+export const SCENARIOS: Scenario[] = [
+  {
+    id: "current", name: "Current spend", note: "Status quo — mirrors live inputs",
+    partnerWorking: true, includeInvest: false, includeBusiness: false,
+    joint: snap(JOINT_EXPENSES), ashtonP: snap(ASHTON_PERSONAL), mariaP: snap(MARIA_PERSONAL),
+  },
+  {
+    id: "lean", name: "Lean mode", note: "Cut discretionary, keep essentials",
+    partnerWorking: true, includeInvest: false, includeBusiness: false,
+    joint: snap(JOINT_EXPENSES), ashtonP: snap(ASHTON_PERSONAL), mariaP: snap(MARIA_PERSONAL),
+  },
+  {
+    id: "solo_lean", name: "Solo lean", note: "No partner income, draw on investments",
+    partnerWorking: false, includeInvest: true, includeBusiness: true,
+    joint: snap(JOINT_EXPENSES), ashtonP: snap(ASHTON_PERSONAL), mariaP: snap(MARIA_PERSONAL),
+  },
+  {
+    id: "baby", name: "Baby year", note: "Lower income, higher costs",
+    partnerWorking: false, includeInvest: false, includeBusiness: false,
+    joint: snap(JOINT_EXPENSES), ashtonP: snap(ASHTON_PERSONAL), mariaP: snap(MARIA_PERSONAL),
+  },
+  {
+    id: "sabbatical", name: "Sabbatical", note: "Stop working, live off pot",
+    partnerWorking: false, includeInvest: true, includeBusiness: true,
+    joint: snap(JOINT_EXPENSES), ashtonP: snap(ASHTON_PERSONAL), mariaP: snap(MARIA_PERSONAL),
+  },
+];
+
+export const NET_WORTH_HISTORY = [
+  { m: "May '25", v: 122400 }, { m: "Jun '25", v: 126800 }, { m: "Jul '25", v: 130900 },
+  { m: "Aug '25", v: 133600 }, { m: "Sep '25", v: 137200 }, { m: "Oct '25", v: 139800 },
+  { m: "Nov '25", v: 142400 }, { m: "Dec '25", v: 144900 }, { m: "Jan '26", v: 146900 },
+  { m: "Feb '26", v: 148700 }, { m: "Mar '26", v: 150000 }, { m: "Apr '26", v: 151406 },
+];
+
+export function fmt(n: number, cur = "EUR", opts: { decimals?: number; signed?: boolean } = {}) {
+  const { decimals = 0, signed = false } = opts;
+  const sign = signed && n > 0 ? "+" : "";
+  const v = Math.abs(n).toLocaleString("en-US", { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+  const sym = cur === "EUR" ? "€" : cur === "USD" ? "$" : cur === "GBP" ? "£" : cur === "CAD" ? "C$" : "";
+  return `${sign}${n < 0 ? "−" : ""}${sym}${v}`;
+}
+
+export function fmtFig(n: number, cur = "EUR") {
+  const neg = n < 0;
+  const abs = Math.abs(n);
+  const whole = Math.floor(abs).toLocaleString("en-US");
+  const dec = (abs % 1).toFixed(2).slice(1);
+  const sym = cur === "EUR" ? "€" : cur === "USD" ? "$" : cur === "GBP" ? "£" : cur === "CAD" ? "C$" : "€";
+  return { sym, whole: (neg ? "−" : "") + whole, dec };
+}

--- a/app/pages/ledger/primitives.tsx
+++ b/app/pages/ledger/primitives.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, type ReactNode, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
+import { fmtFig } from "./data.js";
+
+export function Figure({ value, cur = "EUR", size = 42, showDec = true, unit = "", className = "" }:
+  { value: number; cur?: string; size?: number; showDec?: boolean; unit?: string; className?: string }) {
+  if (unit) {
+    const whole = Math.round(value).toLocaleString("en-US");
+    return (
+      <span className={`figure ${className}`} style={{ fontSize: size }}>
+        {whole}
+        <span className="decimal" style={{ marginLeft: 6, fontFamily: "var(--italic)", fontStyle: "italic" }}>{unit}</span>
+      </span>
+    );
+  }
+  const { sym, whole, dec } = fmtFig(value, cur);
+  return (
+    <span className={`figure ${className}`} style={{ fontSize: size }}>
+      <span className="cur">{sym}</span>
+      {whole}
+      {showDec && <span className="decimal">{dec}</span>}
+    </span>
+  );
+}
+
+export function Delta({ value, unit = "%", className = "" }: { value: number; unit?: string; className?: string }) {
+  const pos = value > 0;
+  return (
+    <span className={`delta ${pos ? "pos" : "neg"} ${className}`}>
+      {pos ? "▲" : "▼"} {Math.abs(value).toFixed(1)}{unit}
+    </span>
+  );
+}
+
+export function Smallcaps({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return <span className={`smallcaps ${className}`}>{children}</span>;
+}
+
+export function Panel({ title, meta, children, variant = "ruled", flush = false, tight = false, action }:
+  { title?: ReactNode; meta?: ReactNode; children: ReactNode; variant?: string; flush?: boolean; tight?: boolean; action?: ReactNode }) {
+  return (
+    <div className={`panel ${variant}`}>
+      {(title || meta || action) && (
+        <div className="panel-head">
+          <div className="title">{title}</div>
+          {meta && <div className="meta">{meta}</div>}
+          {action && <div style={{ marginLeft: "auto" }}>{action}</div>}
+        </div>
+      )}
+      <div className={`panel-body ${flush ? "flush" : ""} ${tight ? "tight" : ""}`}>{children}</div>
+    </div>
+  );
+}
+
+export function Stat({ label, value, cur = "EUR", unit = "", sub, delta, note, size = 42, showDec = true }:
+  { label: ReactNode; value: number; cur?: string; unit?: string; sub?: ReactNode; delta?: number | null; note?: ReactNode; size?: number; showDec?: boolean }) {
+  return (
+    <div className="panel ruled stat">
+      <div className="label">
+        <span>{label}</span>
+        {note && <span>{note}</span>}
+      </div>
+      <Figure value={value} cur={cur} unit={unit} size={size} showDec={showDec} />
+      {(sub || (delta !== undefined && delta !== null)) && (
+        <div className="sub">
+          {delta !== undefined && delta !== null && <Delta value={delta} />} {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function Bar({ pct, variant = "", height = 6 }: { pct: number; variant?: string; height?: number }) {
+  const p = Math.max(0, Math.min(100, pct));
+  return (
+    <div className={`bar ${variant}`} style={{ height }}>
+      <div className="fill" style={{ right: `${100 - p}%` }} />
+    </div>
+  );
+}
+
+export function StackedBar({ segs, height = 6 }: { segs: { pct: number; color: string }[]; height?: number }) {
+  return (
+    <div className="bar stacked" style={{ height }}>
+      {segs.map((s, i) => (
+        <div key={i} className="fill" style={{ flex: s.pct, background: s.color }} />
+      ))}
+    </div>
+  );
+}
+
+export function Segmented<T extends string>({ options, value, onChange }:
+  { options: { value: T; label: string }[]; value: T; onChange: (v: T) => void }) {
+  return (
+    <div className="segmented">
+      {options.map(o => (
+        <button key={o.value} className={value === o.value ? "on" : ""} onClick={() => onChange(o.value)}>
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function EditableCell({ value, onChange, prefix = "", suffix = "", align = "right", format = (v: number) => v.toLocaleString("en-US") }:
+  { value: number; onChange: (v: number) => void; prefix?: string; suffix?: string; align?: "left" | "right" | "center"; format?: (v: number) => string }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(value));
+  useEffect(() => { setDraft(String(value)); }, [value]);
+  const commit = () => {
+    const n = parseFloat(draft.replace(/[,\s]/g, ""));
+    if (!isNaN(n)) onChange(n);
+    setEditing(false);
+  };
+  return (
+    <td className="num editable" onClick={() => setEditing(true)}>
+      {editing ? (
+        <input
+          className="cell-input mono"
+          autoFocus
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={e => { if (e.key === "Enter") commit(); if (e.key === "Escape") setEditing(false); }}
+          style={{ textAlign: align as CSSProperties["textAlign"] }}
+        />
+      ) : (
+        <>{prefix}{format(value)}{suffix}</>
+      )}
+    </td>
+  );
+}
+
+export function Chip({ children, tone }: { children: ReactNode; tone?: string }) {
+  return <span className={`chip ${tone || ""}`}>{children}</span>;
+}
+
+export function Who({ who, label }: { who: "ashton" | "partner" | string; label?: string }) {
+  const cls = who === "ashton" ? "ashton" : who === "partner" ? "e" : "";
+  return <span className={`who ${cls}`}><span className="dot" />{label || who}</span>;
+}
+
+export function Folio({ section, title, dek, no, date = "19 APRIL 2026" }:
+  { section: ReactNode; title: ReactNode; dek?: ReactNode; no?: string; date?: string }) {
+  return (
+    <header className="folio">
+      <div className="left">
+        <span>№ {no || "I"}</span>
+        <span>·</span>
+        <span>{date}</span>
+      </div>
+      <div className="center">
+        <div className="kicker">{section}</div>
+        <h2>{title}</h2>
+        {dek && <div className="dek">{dek}</div>}
+      </div>
+      <div className="right">
+        <span>VOL. III</span>
+        <span>·</span>
+        <span>HELSINKI</span>
+      </div>
+    </header>
+  );
+}
+
+export function LedgerModal({ title, meta, onClose, children, wide = false }: {
+  title: ReactNode; meta?: ReactNode; onClose: () => void; children: ReactNode; wide?: boolean;
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className="ledger-root ledger-modal-backdrop"
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className={`ledger-modal${wide ? " wide" : ""}`}>
+        <div className="ledger-modal-head">
+          <span className="title">{title}</span>
+          {meta && <span className="meta">{meta}</span>}
+          <button className="ledger-modal-close" onClick={onClose}>×</button>
+        </div>
+        <div className="ledger-modal-body">{children}</div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/pages/ledger/screens/Dashboard.tsx
+++ b/app/pages/ledger/screens/Dashboard.tsx
@@ -1,0 +1,357 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { Folio, Panel, Segmented, Smallcaps, Stat, Who } from "../primitives.js";
+import { AreaChart, Donut } from "../charts.js";
+import { BUSINESS, CATEGORIES, NET_WORTH_HISTORY, deriveBiz, fmt, fx } from "../data.js";
+import type { Asset } from "../data.js";
+import type { Derived, LedgerState } from "../state.js";
+
+export function Dashboard({ state, d }: { state: LedgerState; d: Derived }) {
+  const { dashView, setDashView } = state;
+  const vals = NET_WORTH_HISTORY.map(h => h.v);
+  const mom = ((vals[vals.length - 1] - vals[vals.length - 2]) / vals[vals.length - 2]) * 100;
+
+  // Joint pot uses ALL accessible assets (liquid + brokerage + business), not just cash.
+  // This matches what Ashton's individual view does (liquidA + businessAssets).
+  const heroMap = {
+    joint: {
+      net: d.netWorth,
+      netLabel: "Household net worth",
+      netSub: `€${Math.round(d.totalAssets).toLocaleString()} assets · €${Math.round(d.totalDebt).toLocaleString()} debt · €${Math.round(d.iouNet).toLocaleString()} IOU`,
+      saving: d.hhSaving,
+      savingLabel: "Household saving",
+      savingSub: `${Math.round(d.hhSaving / d.hhIncome * 100)}% of €${Math.round(d.hhIncome).toLocaleString()} combined income`,
+      runwayPot: d.liquidAssets + d.brokerageAssets + d.businessAssets,
+      runwayBurn: d.hhBurn,
+    },
+    ashton: {
+      net: d.netWorthA,
+      netLabel: "Ashton net worth",
+      netSub: `€${Math.round(d.personalAssetsA + d.businessAssets).toLocaleString()} assets · €${Math.round(d.debtA).toLocaleString()} debt · €${Math.round(d.iouNet).toLocaleString()} IOU`,
+      saving: d.aIncome - d.aBurn,
+      savingLabel: "Ashton saving",
+      savingSub: `€${Math.round(d.aIncome).toLocaleString()} in · €${Math.round(d.aBurn).toLocaleString()} out (€${Math.round(d.aPersonal).toLocaleString()} personal + €${Math.round(d.jointTotal * d.aShare).toLocaleString()} joint share)`,
+      runwayPot: d.liquidA + d.businessAssets,
+      runwayBurn: d.aBurn,
+    },
+    partner: {
+      net: d.netWorthM,
+      netLabel: "Maria net worth",
+      netSub: `€${Math.round(d.personalAssetsM).toLocaleString()} assets · €${Math.round(d.debtM).toLocaleString()} debt`,
+      saving: d.mIncome - d.mBurn,
+      savingLabel: "Maria saving",
+      savingSub: `€${Math.round(d.mIncome).toLocaleString()} in · €${Math.round(d.mBurn).toLocaleString()} out (€${Math.round(d.mPersonal).toLocaleString()} personal + €${Math.round(d.jointTotal * d.mShare).toLocaleString()} joint share)`,
+      runwayPot: d.liquidM,
+      runwayBurn: d.mBurn,
+    },
+  } as const;
+  const hero = heroMap[dashView];
+
+  const runwayMonths = Math.floor(hero.runwayPot / Math.max(100, hero.runwayBurn));
+
+  const assetsMeta = dashView === "joint"
+    ? `€${Math.round(d.totalAssets).toLocaleString()}`
+    : dashView === "ashton"
+    ? `€${Math.round(d.personalAssetsA + d.businessAssets).toLocaleString()}`
+    : `€${Math.round(d.personalAssetsM).toLocaleString()}`;
+
+  return (
+    <>
+      <Folio section="The Ledger" title="Dashboard" no="I"
+        dek="The household, the business, and the long view — on one page." />
+
+      <div className="content">
+        <div className="flex-between mb-md" style={{ alignItems: "center" }}>
+          <Smallcaps>Viewing as</Smallcaps>
+          <Segmented
+            value={dashView}
+            onChange={setDashView}
+            options={[
+              { value: "joint", label: "Joint" },
+              { value: "ashton", label: "Ashton" },
+              { value: "partner", label: "Maria" },
+            ]}
+          />
+        </div>
+
+        {/* Headline: assets chart + key stats */}
+        <div className="grid g-2">
+          <Panel title="Assets" meta={assetsMeta}>
+            <AssetsPanel dashView={dashView} d={d} state={state} />
+          </Panel>
+          <div className="flex-col gap-sm">
+            <Stat label={`Runway — ${dashView}`} value={runwayMonths} unit="months" size={60}
+              sub={`at €${Math.round(hero.runwayBurn).toLocaleString()}/mo burn · pot €${Math.round(hero.runwayPot).toLocaleString()}`} />
+            <Stat label={hero.savingLabel} value={hero.saving} size={38} showDec={false} sub={hero.savingSub} />
+            <Stat label={hero.netLabel} note="EUR equiv." value={hero.net} size={38} showDec={false}
+              sub={hero.netSub} delta={dashView === "joint" ? mom : null} />
+          </div>
+        </div>
+
+        <div className="grid g-2">
+          <Panel title="This month" meta={dashView === "joint" ? "household flow" : `${dashView === "ashton" ? "Ashton" : "Maria"} flow`}>
+            {dashView === "joint" ? <JointTable d={d} state={state} /> :
+              dashView === "ashton" ? <PersonTable who="ashton" d={d} /> :
+                <PersonTable who="partner" d={d} />}
+          </Panel>
+
+          <CategoryComparison state={state} d={d} />
+        </div>
+
+        {/* Net worth chart — at bottom */}
+        <Panel title="Net worth, 12 months" meta={`current €${Math.round(d.netWorth).toLocaleString()} · MoM ${mom >= 0 ? "+" : "−"}${Math.abs(mom).toFixed(1)}%`}>
+          <AreaChart data={NET_WORTH_HISTORY} style="engraved" height={240} />
+        </Panel>
+      </div>
+    </>
+  );
+}
+
+function JointTable({ d, state }: { d: Derived; state: LedgerState }) {
+  const b = deriveBiz(
+    { monthlyRevenue: state.bizRevenue, costs: state.bizCosts, grossSalary: BUSINESS.grossSalary, dividendMonthly: state.income.ashton.dividend },
+    state.tax,
+  );
+  return (
+    <table className="table">
+      <tbody>
+        <tr className="subtotal"><td colSpan={2} style={{ paddingBottom: 2 }}>Business (Ashton's Oy)</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>Revenue</td><td className="num">€{Math.round(state.bizRevenue).toLocaleString()}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>Operating costs</td><td className="num neg">−€{Math.round(d.bizCostTotal).toLocaleString()}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>→ Salary + dividend to Ashton</td><td className="num">€{Math.round(b.netSalary + b.dividendNet).toLocaleString()}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>→ Retained in Oy</td><td className="num">€{Math.round(b.retained).toLocaleString()}</td></tr>
+        <tr className="subtotal"><td colSpan={2} style={{ paddingBottom: 2, paddingTop: 8 }}>Household cashflow</td></tr>
+        <tr><td><Who who="ashton" label="Ashton income" /></td><td className="num">€{Math.round(d.aIncome).toLocaleString()}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14, color: "var(--ink-3)" }}>Business retained in Oy</td><td className="num" style={{ color: "var(--ink-3)" }}>€{Math.round(b.retained).toLocaleString()}</td></tr>
+        <tr><td><Who who="partner" label="Maria income" /></td><td className="num">€{Math.round(d.mIncome).toLocaleString()}</td></tr>
+        <tr className="subtotal"><td>Combined income (incl. retained)</td><td className="num">€{Math.round(d.hhIncome + b.retained).toLocaleString()}</td></tr>
+        <tr><td>Joint expenses</td><td className="num neg">−€{Math.round(d.jointTotal).toLocaleString()}</td></tr>
+        <tr><td>Ashton personal</td><td className="num neg">−€{Math.round(d.aPersonal).toLocaleString()}</td></tr>
+        <tr><td>Maria personal</td><td className="num neg">−€{Math.round(d.mPersonal).toLocaleString()}</td></tr>
+        <tr className="total"><td>Net monthly saving</td><td className={`num ${d.hhSaving > 0 ? "pos" : "neg"}`}>€{Math.round(d.hhSaving).toLocaleString()}</td></tr>
+      </tbody>
+    </table>
+  );
+}
+
+function PersonTable({ who, d }: { who: "ashton" | "partner"; d: Derived }) {
+  const A = who === "ashton";
+  const income = A ? d.aIncome : d.mIncome;
+  const personal = A ? d.aPersonal : d.mPersonal;
+  const jointShare = d.jointTotal * (A ? d.aShare : d.mShare);
+  const net = income - personal - jointShare;
+  return (
+    <table className="table">
+      <tbody>
+        <tr><td>Take-home income</td><td className="num">€{Math.round(income).toLocaleString()}</td></tr>
+        <tr><td>Share of joint ({((A ? d.aShare : d.mShare) * 100) | 0}%)</td>
+          <td className="num neg">−€{Math.round(jointShare).toLocaleString()}</td></tr>
+        <tr><td>Personal spending</td>
+          <td className="num neg">−€{Math.round(personal).toLocaleString()}</td></tr>
+        <tr className="total"><td>Surplus</td>
+          <td className={`num ${net >= 0 ? "pos" : "neg"}`}>€{Math.round(net).toLocaleString()}</td></tr>
+      </tbody>
+    </table>
+  );
+}
+
+function AssetsPanel({ dashView, d, state }: { dashView: "joint" | "ashton" | "partner"; d: Derived; state: LedgerState }) {
+  if (dashView === "partner") {
+    const rows: Asset[] = state.assets.filter(a => a.owner === "partner");
+    return (
+      <div>
+        <table className="table">
+          <tbody>
+            {rows.map(a => (
+              <tr key={a.id}>
+                <td>{a.label}</td>
+                <td className="mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>{a.type}</td>
+                <td className="num">{fmt(a.bal * fx[a.cur])}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+  const seg = dashView === "ashton"
+    ? [
+      { value: d.liquidA, color: "var(--ink)", label: "Liquid (Ashton)" },
+      { value: d.brokerageAssets, color: "var(--rust)", label: "Brokerage" },
+      { value: d.pensionAssets - 14000, color: "var(--moss)", label: "Swiss pension" },
+    ]
+    : [
+      { value: d.liquidAssets, color: "var(--ink)", label: "Liquid" },
+      { value: d.brokerageAssets, color: "var(--rust)", label: "Brokerage" },
+      { value: d.businessAssets - d.brokerageAssets, color: "var(--ochre)", label: "Business (excl. brokerage)" },
+      { value: d.pensionAssets, color: "var(--moss)", label: "Pension" },
+    ];
+  return (
+    <div className="flex gap-md" style={{ alignItems: "center" }}>
+      <Donut segs={seg} size={160} />
+      <div className="flex-col gap-sm" style={{ fontSize: 13, flex: 1 }}>
+        {seg.map((s, i) => (
+          <div key={i} className="flex-between">
+            <span><span style={{ width: 8, height: 8, background: s.color, display: "inline-block", marginRight: 6 }} />{s.label}</span>
+            <span className="mono">€{Math.round(s.value).toLocaleString()}</span>
+          </div>
+        ))}
+        <hr className="rule" style={{ margin: "4px 0" }} />
+        <div className="flex-between italic" style={{ color: "var(--crimson)" }}>
+          <span>Debts</span>
+          <span className="mono">−€{Math.round(dashView === "ashton" ? d.debtA : d.totalDebt).toLocaleString()}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CatItem { label: string; amt: number; joint?: boolean }
+interface CatRow { ashton: number; partner: number; ashtonItems: CatItem[]; partnerItems: CatItem[] }
+
+function CategoryComparison({ state, d }: { state: LedgerState; d: Derived }) {
+  const [tooltip, setTooltip] = useState<{ cat: string; x: number; y: number; row: CatRow } | null>(null);
+
+  const byCat: Record<string, CatRow> = {};
+  const ensure = (cat: string) => {
+    if (!byCat[cat]) byCat[cat] = { ashton: 0, partner: 0, ashtonItems: [], partnerItems: [] };
+  };
+  state.ashtonP.forEach(e => {
+    ensure(e.cat || "other");
+    byCat[e.cat || "other"].ashton += e.amt;
+    byCat[e.cat || "other"].ashtonItems.push({ label: e.label, amt: e.amt });
+  });
+  state.mariaP.forEach(e => {
+    ensure(e.cat || "other");
+    byCat[e.cat || "other"].partner += e.amt;
+    byCat[e.cat || "other"].partnerItems.push({ label: e.label, amt: e.amt });
+  });
+  state.joint.forEach(j => {
+    ensure(j.cat || "other");
+    byCat[j.cat || "other"].ashton += j.amt * d.aShare;
+    byCat[j.cat || "other"].partner += j.amt * d.mShare;
+    byCat[j.cat || "other"].ashtonItems.push({ label: j.label, amt: j.amt * d.aShare, joint: true });
+    byCat[j.cat || "other"].partnerItems.push({ label: j.label, amt: j.amt * d.mShare, joint: true });
+  });
+
+  const rows = Object.entries(byCat)
+    .map(([cat, v]) => ({ cat, ...v, total: v.ashton + v.partner }))
+    .sort((a, b) => b.total - a.total);
+
+  const maxTotal = Math.max(...rows.map(r => r.total));
+
+  return (
+    <Panel title="Spending by category — Ashton vs Maria" meta="includes share of joint expenses">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th className="num"><Who who="ashton" label="Ashton" /></th>
+            <th className="num"><Who who="partner" label="Maria" /></th>
+            <th className="num">Total</th>
+            <th style={{ width: 200 }}>Split</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => {
+            const catMeta = CATEGORIES[r.cat] || { label: r.cat, color: "#555" };
+            const aPct = r.total ? r.ashton / r.total * 100 : 0;
+            return (
+              <tr key={r.cat}
+                style={{ cursor: "default" }}
+                onMouseEnter={(e) => {
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  setTooltip({ cat: r.cat, x: rect.left + rect.width / 2, y: rect.bottom + 4, row: r });
+                }}
+                onMouseLeave={() => setTooltip(null)}>
+                <td>
+                  <span style={{ display: "inline-block", width: 10, height: 10, background: catMeta.color, marginRight: 8, verticalAlign: "middle" }} />
+                  {catMeta.label}
+                </td>
+                <td className="num">€{r.ashton.toFixed(0)}</td>
+                <td className="num">€{r.partner.toFixed(0)}</td>
+                <td className="num" style={{ fontWeight: 600 }}>€{r.total.toFixed(0)}</td>
+                <td><SplitBar aPct={aPct} width={r.total / maxTotal * 100} /></td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {tooltip && createPortal(<CatTooltip tooltip={tooltip} />, document.body)}
+    </Panel>
+  );
+}
+
+function CatTooltip({ tooltip }: { tooltip: { cat: string; x: number; y: number; row: CatRow } }) {
+  const { x, y, row } = tooltip;
+  const catMeta = CATEGORIES[tooltip.cat] || { label: tooltip.cat, color: "#555" };
+  const allItems = [
+    ...row.ashtonItems.map(i => ({ ...i, who: "ashton" as const })),
+    ...row.partnerItems.map(i => ({ ...i, who: "partner" as const })),
+  ];
+  // Merge joint items (same label appears in both ashton and partner)
+  const merged: { label: string; ashton: number; partner: number; joint: boolean }[] = [];
+  const seen: Record<string, number> = {};
+  allItems.forEach(item => {
+    const key = item.label + (item.joint ? "#j" : `#${item.who}`);
+    if (seen[key] !== undefined) {
+      merged[seen[key]][item.who] = (merged[seen[key]][item.who] || 0) + item.amt;
+    } else {
+      seen[key] = merged.length;
+      merged.push({ label: item.label, ashton: item.who === "ashton" ? item.amt : 0, partner: item.who === "partner" ? item.amt : 0, joint: !!item.joint });
+    }
+  });
+  merged.sort((a, b) => (b.ashton + b.partner) - (a.ashton + a.partner));
+
+  const w = 320;
+  const left = Math.min(Math.max(x - w / 2, 8), window.innerWidth - w - 8);
+
+  return (
+    <div className="ledger-root" style={{
+      position: "fixed", top: y, left, width: w, zIndex: 9999,
+      background: "var(--paper)", border: "1px solid var(--rule)", borderRadius: 4,
+      boxShadow: "0 4px 16px rgba(0,0,0,0.15)", padding: "10px 14px",
+      pointerEvents: "none",
+    }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <span style={{ width: 10, height: 10, background: catMeta.color, display: "inline-block", flexShrink: 0 }} />
+        <span style={{ fontFamily: "var(--mono)", fontSize: 11, letterSpacing: "0.1em", color: "var(--ink-2)" }}>{catMeta.label.toUpperCase()}</span>
+      </div>
+      <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+        <thead>
+          <tr style={{ color: "var(--ink-3)", fontFamily: "var(--mono)", fontSize: 10 }}>
+            <th style={{ textAlign: "left", paddingBottom: 4, fontWeight: 400 }}>Item</th>
+            <th style={{ textAlign: "right", paddingBottom: 4, fontWeight: 400 }}>A</th>
+            <th style={{ textAlign: "right", paddingBottom: 4, fontWeight: 400 }}>M</th>
+          </tr>
+        </thead>
+        <tbody>
+          {merged.map((m, i) => (
+            <tr key={i} style={{ borderTop: "1px solid var(--rule-soft)" }}>
+              <td style={{ padding: "3px 0", color: "var(--ink)", fontFamily: "var(--serif)" }}>
+                {m.label}{m.joint && <span style={{ color: "var(--ink-3)", fontSize: 10, marginLeft: 4 }}>joint</span>}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: m.ashton ? "var(--ink)" : "var(--ink-4)" }}>
+                {m.ashton ? `€${Math.round(m.ashton)}` : "—"}
+              </td>
+              <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: m.partner ? "var(--ink)" : "var(--ink-4)" }}>
+                {m.partner ? `€${Math.round(m.partner)}` : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SplitBar({ aPct, width }: { aPct: number; width: number }) {
+  return (
+    <div style={{ height: 12, background: "var(--paper-2)", position: "relative" }}>
+      <div style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: `${width}%`, display: "flex" }}>
+        <div style={{ width: `${aPct}%`, background: "var(--ink)" }} />
+        <div style={{ flex: 1, background: "var(--ink-3)" }} />
+      </div>
+    </div>
+  );
+}

--- a/app/pages/ledger/screens/Flow.tsx
+++ b/app/pages/ledger/screens/Flow.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useRef, useState } from "react";
+import { Folio, LedgerModal, Panel, Smallcaps } from "../primitives.js";
+import { BUSINESS, CATEGORIES, deriveBiz } from "../data.js";
+import type { Expense } from "../data.js";
+import type { Derived, LedgerState } from "../state.js";
+
+export function Flow({ state, d }: { state: LedgerState; d: Derived }) {
+  const { bizRevenue, bizCosts, tax } = state;
+  const [byCategory, setByCategory] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem("ledger.flowByCat") === "1";
+  });
+  useEffect(() => { localStorage.setItem("ledger.flowByCat", byCategory ? "1" : "0"); }, [byCategory]);
+
+  const biz = {
+    monthlyRevenue: bizRevenue, costs: bizCosts,
+    grossSalary: BUSINESS.grossSalary, dividendMonthly: state.income.ashton.dividend,
+  };
+  const b = deriveBiz(biz, tax);
+
+  const mGross = state.income.partner.gross || state.income.partner.total;
+  const mTax = mGross * tax.mariaTaxRate;
+  const mNet = mGross - mTax;
+
+  const ashtonNet = b.netSalary + b.dividendNet;
+  const jointTotal = d.jointTotal;
+  const aJointShare = jointTotal * d.aShare;
+  const mJointShare = jointTotal * d.mShare;
+  const aLeftover = Math.max(0, ashtonNet - aJointShare - d.aPersonal);
+  const mLeftover = Math.max(0, mNet - mJointShare - d.mPersonal);
+
+  const [fullscreen, setFullscreen] = useState(false);
+
+  const svgProps: FullFlowProps = {
+    bizRevenue, bizCostTotal: b.opCosts, grossSalary: BUSINESS.grossSalary,
+    salaryTax: b.salaryTax, netSalary: b.netSalary,
+    preTaxProfit: b.preTaxProfit, corpTax: b.corpTax, afterCorp: b.afterCorp,
+    dividendGross: b.dividendGross, dividendTax: b.dividendTax, dividendNet: b.dividendNet,
+    retained: b.retained, ashtonNet,
+    mGross, mTax, mNet,
+    aJointShare, mJointShare,
+    aPersonal: d.aPersonal, mPersonal: d.mPersonal, aLeftover, mLeftover,
+    jointTotal, byCategory,
+    joint: state.joint, ashtonP: state.ashtonP, mariaP: state.mariaP,
+    aShare: d.aShare, mShare: d.mShare,
+  };
+
+  return (
+    <>
+      <Folio section="Section II" title="Money flow" no="II"
+        dek="From business revenue through three tax gates (salary, corporate, dividend) to the things the money actually does." />
+
+      <div className="content">
+        <Panel title="Monthly cashflow — April"
+          meta={`Biz €${Math.round(bizRevenue).toLocaleString()} in · Ashton net €${Math.round(ashtonNet).toLocaleString()} · Maria net €${Math.round(mNet).toLocaleString()}`}
+          action={
+            <button className="btn" style={{ padding: "3px 10px", fontSize: 9 }} onClick={() => setFullscreen(true)}>
+              ⤢ Fullscreen
+            </button>
+          }>
+          <div className="flex-between mb-md" style={{ alignItems: "center" }}>
+            <Smallcaps>{byCategory ? "with category breakdown" : "simple destinations"}</Smallcaps>
+            <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer", fontSize: 12 }}>
+              <input type="checkbox" checked={byCategory}
+                onChange={e => setByCategory(e.target.checked)} />
+              <span className="smallcaps">Split destinations by category</span>
+            </label>
+          </div>
+          <FullFlow {...svgProps} />
+        </Panel>
+
+        {fullscreen && (
+          <LedgerModal title="Monthly cashflow — April" wide onClose={() => setFullscreen(false)}>
+            <div style={{ padding: 16, height: "100%", overflow: "auto" }}>
+              <FullFlow {...svgProps} />
+            </div>
+          </LedgerModal>
+        )}
+
+        <div className="grid g-2">
+          <Panel title="Business — Ashton's Oy" meta={`€${Math.round(bizRevenue).toLocaleString()}/mo in`}>
+            <table className="table">
+              <tbody>
+                <tr><td>Gross revenue</td><td className="num">€{bizRevenue.toLocaleString()}</td></tr>
+                <tr><td className="italic">Operating costs</td><td className="num neg">−€{Math.round(b.opCosts).toLocaleString()}</td></tr>
+                <tr><td className="italic">Gross salary booked to Ashton</td><td className="num neg">−€{Math.round(BUSINESS.grossSalary).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>→ Salary tax ({(tax.salaryTaxRate * 100).toFixed(1)}%) to state</td><td className="num neg">−€{Math.round(b.salaryTax).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>→ Net salary to Ashton</td><td className="num">€{Math.round(b.netSalary).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>Pre-tax profit</td><td className="num">€{Math.round(b.preTaxProfit).toLocaleString()}</td></tr>
+                <tr><td>Corporate tax ({(tax.corpTaxRate * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(b.corpTax).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>After-tax profit</td><td className="num">€{Math.round(b.afterCorp).toLocaleString()}</td></tr>
+                <tr><td>Dividend declared</td><td className="num neg">−€{Math.round(b.dividendGross).toLocaleString()}</td></tr>
+                <tr className="total"><td>Retained in Oy</td><td className={`num ${b.retained >= 0 ? "pos" : "neg"}`}>€{Math.round(b.retained).toLocaleString()}</td></tr>
+              </tbody>
+            </table>
+          </Panel>
+
+          <Panel title="Ashton — take-home (two streams)" meta={`€${Math.round(ashtonNet).toLocaleString()}/mo`}>
+            <table className="table">
+              <tbody>
+                <tr><td>Net salary (after {(tax.salaryTaxRate * 100).toFixed(1)}% withholding)</td><td className="num">€{Math.round(b.netSalary).toLocaleString()}</td></tr>
+                <tr><td>Dividend declared</td><td className="num">€{Math.round(b.dividendGross).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>− dividend tax ({(tax.dividendTaxRate * 100).toFixed(1)}%)</td><td className="num neg">−€{Math.round(b.dividendTax).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>= dividend net</td><td className="num">€{Math.round(b.dividendNet).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>Spendable</td><td className="num">€{Math.round(ashtonNet).toLocaleString()}</td></tr>
+                <tr><td>Share of joint ({(d.aShare * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(aJointShare).toLocaleString()}</td></tr>
+                <tr><td>Personal spend</td><td className="num neg">−€{Math.round(d.aPersonal).toLocaleString()}</td></tr>
+                <tr className="total"><td>Surplus</td><td className={`num ${aLeftover >= 0 ? "pos" : "neg"}`}>€{Math.round(aLeftover).toLocaleString()}</td></tr>
+              </tbody>
+            </table>
+          </Panel>
+        </div>
+
+        <Panel title="Maria — salary → spendable" meta={`€${Math.round(mGross).toLocaleString()}/mo gross`}>
+          <table className="table">
+            <tbody>
+              <tr><td>Gross salary</td><td className="num">€{mGross.toLocaleString()}</td></tr>
+              <tr><td className="italic">Income tax + social contributions ({(tax.mariaTaxRate * 100).toFixed(1)}%)</td><td className="num neg">−€{Math.round(mTax).toLocaleString()}</td></tr>
+              <tr className="subtotal"><td>Net take-home</td><td className="num">€{Math.round(mNet).toLocaleString()}</td></tr>
+              <tr><td>Share of joint ({(d.mShare * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(mJointShare).toLocaleString()}</td></tr>
+              <tr><td>Personal spend</td><td className="num neg">−€{Math.round(d.mPersonal).toLocaleString()}</td></tr>
+              <tr className="total"><td>Surplus</td><td className={`num ${mLeftover >= 0 ? "pos" : "neg"}`}>€{Math.round(mLeftover).toLocaleString()}</td></tr>
+            </tbody>
+          </table>
+        </Panel>
+      </div>
+    </>
+  );
+}
+
+interface FullFlowProps {
+  bizRevenue: number; bizCostTotal: number; grossSalary: number;
+  salaryTax: number; netSalary: number;
+  preTaxProfit: number; corpTax: number; afterCorp: number;
+  dividendGross: number; dividendTax: number; dividendNet: number; retained: number;
+  ashtonNet: number;
+  mGross: number; mTax: number; mNet: number;
+  aJointShare: number; mJointShare: number;
+  aPersonal: number; mPersonal: number; aLeftover: number; mLeftover: number;
+  jointTotal: number;
+  byCategory: boolean;
+  joint: Expense[]; ashtonP: Expense[]; mariaP: Expense[];
+  aShare: number; mShare: number;
+}
+
+interface FlowNode { id: string; label: string; value: number; color: string; x: number; y: number; h: number; sources?: Record<string, number>; }
+interface LinkDef { from: string; to: string; value: number; color: string; }
+
+function FullFlow(props: FullFlowProps) {
+  const {
+    bizRevenue, bizCostTotal, grossSalary, salaryTax, netSalary,
+    preTaxProfit, corpTax, afterCorp, dividendGross, dividendTax, dividendNet, retained,
+    ashtonNet,
+    mGross, mTax, mNet,
+    aJointShare, mJointShare, aPersonal, mPersonal, aLeftover, mLeftover, jointTotal,
+    byCategory, joint, ashtonP, mariaP, aShare, mShare,
+  } = props;
+
+  const [hovered, setHovered] = useState<{ from: string; to: string; value: number; color: string; x: number; y: number } | null>(null);
+  // colOrders stores the user-dragged order for each reorderable column key
+  const [colOrders, setColOrders] = useState<Record<string, string[]>>({});
+  const [dragging, setDragging] = useState<{ colKey: string; nodeId: string } | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const W = 1360;
+  const pad = 36;
+  const headerPad = 36;
+  const nodeW = 14;
+  const GAP = 10;
+  const total = bizRevenue + mGross;
+
+  // Scale is independent of canvas height — avoids circular dependency
+  const vScale = (v: number) => Math.max(3, v / total * 480);
+
+  // Sum of scaled heights for a column, with gaps between items
+  const colH = (...vals: number[]) => {
+    const pos = vals.filter(v => v > 0);
+    return pos.map(vScale).reduce((a, b) => a + b, 0) + Math.max(0, pos.length - 1) * GAP;
+  };
+
+  // Compute minimum height needed for each stream so nodes never overlap
+  const topStreamH = Math.max(
+    colH(bizRevenue),
+    colH(bizCostTotal, grossSalary, Math.max(0, preTaxProfit)),
+    colH(salaryTax, netSalary, corpTax, Math.max(0, afterCorp)),
+    colH(dividendGross, Math.max(0, retained)),
+    colH(dividendTax, dividendNet),
+    colH(ashtonNet),
+  );
+  const botStreamH = Math.max(colH(mGross), colH(mTax, mNet), colH(mNet));
+  const destStreamH = colH(jointTotal, aPersonal, aLeftover, mPersonal, mLeftover);
+
+  const COL = {
+    TAX: "#8B3A2E", BIZ: "#5A6B4A", COST: "#B08A3E",
+    ASHTON: "#2A2A27", MARIA: "#6B6864", JOINT: "#B5583A", SAVE: "#5A6B4A",
+  };
+
+  const col = [pad, W * 0.18, W * 0.38, W * 0.56, W * 0.74, W - pad - nodeW - 120];
+
+  function stack(items: Omit<FlowNode, "x" | "y" | "h">[], x: number, topStart: number): FlowNode[] {
+    let y = topStart;
+    return items.map(it => {
+      const h = vScale(it.value);
+      const n: FlowNode = { ...it, x, y, h };
+      y += h + 10;
+      return n;
+    });
+  }
+
+  const topY = pad + headerPad;
+  const botY = topY + topStreamH + 40;
+
+  const getOrder = (key: string, defaults: string[]) => colOrders[key] ?? defaults;
+
+  // Item definitions for each reorderable column
+  const t1Items: Record<string, Omit<FlowNode, "x" | "y" | "h">> = {
+    biz_costs: { id: "biz_costs", label: "Operating costs", value: bizCostTotal, color: COL.COST },
+    gross_sal: { id: "gross_sal", label: "Gross salary (Ashton)", value: grossSalary, color: COL.ASHTON },
+    pre_profit: { id: "pre_profit", label: "Pre-tax profit", value: Math.max(0, preTaxProfit), color: COL.BIZ },
+  };
+  const t2Items: Record<string, Omit<FlowNode, "x" | "y" | "h">> = {
+    sal_tax: { id: "sal_tax", label: "Salary tax → state", value: salaryTax, color: COL.TAX },
+    net_sal: { id: "net_sal", label: "Net salary", value: netSalary, color: COL.ASHTON },
+    corp_tax: { id: "corp_tax", label: "Corporate tax → state", value: corpTax, color: COL.TAX },
+    after_corp: { id: "after_corp", label: "After-tax profit", value: Math.max(0, afterCorp), color: COL.BIZ },
+  };
+  const t3Items: Record<string, Omit<FlowNode, "x" | "y" | "h">> = {
+    div_gross: { id: "div_gross", label: "Dividend (gross)", value: dividendGross, color: COL.ASHTON },
+    retained: { id: "retained", label: "Retained in Oy", value: Math.max(0, retained), color: COL.SAVE },
+  };
+  const t4Items: Record<string, Omit<FlowNode, "x" | "y" | "h">> = {
+    div_tax: { id: "div_tax", label: "Dividend tax → state", value: dividendTax, color: COL.TAX },
+    div_net: { id: "div_net", label: "Dividend (net)", value: dividendNet, color: COL.ASHTON },
+  };
+  const destItemDefs: Record<string, Omit<FlowNode, "x" | "y" | "h">> = {
+    joint:  { id: "joint",  label: "Joint expenses",  value: jointTotal, color: COL.JOINT },
+    a_pers: { id: "a_pers", label: "Ashton personal",  value: aPersonal,  color: COL.COST },
+    a_save: { id: "a_save", label: "Ashton surplus",   value: aLeftover,  color: COL.SAVE },
+    m_pers: { id: "m_pers", label: "Maria personal",   value: mPersonal,  color: COL.COST },
+    m_save: { id: "m_save", label: "Maria surplus",    value: mLeftover,  color: COL.SAVE },
+  };
+
+  // Columns where drag-reorder is enabled
+  const draggableCols: Record<string, { items: Record<string, Omit<FlowNode, "x"|"y"|"h">>; defaults: string[] }> = {
+    t1:    { items: t1Items,    defaults: ["biz_costs", "gross_sal", "pre_profit"] },
+    t2:    { items: t2Items,    defaults: ["sal_tax", "net_sal", "corp_tax", "after_corp"] },
+    t3:    { items: t3Items,    defaults: ["div_gross", "retained"] },
+    t4:    { items: t4Items,    defaults: ["div_tax", "div_net"] },
+    dests: { items: destItemDefs, defaults: ["joint", "a_pers", "a_save", "m_pers", "m_save"] },
+  };
+
+  const t0 = stack([{ id: "biz_rev", label: "Business revenue", value: bizRevenue, color: COL.BIZ }], col[0], topY);
+  const t1 = stack(getOrder("t1", draggableCols.t1.defaults).map(id => t1Items[id]).filter(Boolean), col[1], topY);
+  const t2 = stack(getOrder("t2", draggableCols.t2.defaults).map(id => t2Items[id]).filter(Boolean), col[2], topY);
+  const t3 = stack(getOrder("t3", draggableCols.t3.defaults).map(id => t3Items[id]).filter(Boolean), col[3], topY);
+  const t4 = stack(getOrder("t4", draggableCols.t4.defaults).map(id => t4Items[id]).filter(Boolean), col[4], topY);
+  const t5 = stack([{ id: "a_pool", label: "Ashton spendable", value: ashtonNet, color: COL.ASHTON }], col[5], topY);
+
+  const b0 = stack([{ id: "m_gross", label: "Maria gross salary", value: mGross, color: COL.MARIA }], col[0], botY);
+  const b1 = stack([
+    { id: "m_tax", label: "Income tax → state", value: mTax, color: COL.TAX },
+    { id: "m_net", label: "Net take-home", value: mNet, color: COL.MARIA },
+  ], col[1], botY);
+  const b5 = stack([{ id: "m_pool", label: "Maria spendable", value: mNet, color: COL.MARIA }], col[5], botY);
+
+  const destX = col[5] + 180;
+  const destStart = topY + 20;
+  const dests = stack(
+    getOrder("dests", draggableCols.dests.defaults).map(id => destItemDefs[id]).filter(Boolean),
+    destX, destStart,
+  );
+
+  const catX = destX + 260;
+  let cats: FlowNode[] = [];
+  if (byCategory) {
+    const agg: Record<string, { value: number; sources: Record<string, number> }> = {};
+    const add = (catId: string, source: string, val: number) => {
+      if (val <= 0) return;
+      if (!agg[catId]) agg[catId] = { value: 0, sources: { joint: 0, a_pers: 0, m_pers: 0 } };
+      agg[catId].value += val;
+      agg[catId].sources[source] = (agg[catId].sources[source] || 0) + val;
+    };
+    (joint || []).forEach(j => add(j.cat || "other", "joint", j.amt));
+    (ashtonP || []).forEach(e => add(e.cat || "other", "a_pers", e.amt));
+    (mariaP || []).forEach(e => add(e.cat || "other", "m_pers", e.amt));
+    add("savings", "a_save", aLeftover);
+    add("savings", "m_save", mLeftover);
+    const rows = Object.entries(agg)
+      .map(([id, v]) => ({ id: `cat_${id}`, rawId: id, ...v }))
+      .sort((a, b) => b.value - a.value);
+    cats = stack(rows.map(r => {
+      const meta = CATEGORIES[r.rawId] || { label: r.rawId, color: "#888" };
+      return { id: r.id, label: meta.label, value: r.value, color: meta.color || "#888", sources: r.sources };
+    }), catX, destStart);
+  }
+
+  // Compute final canvas height after all nodes are placed
+  const catColumnH = cats.length ? (cats[cats.length - 1].y + cats[cats.length - 1].h - topY) : 0;
+  const H = Math.max(botY + botStreamH, topY + destStreamH, topY + catColumnH) + pad;
+
+  const allNodes: FlowNode[] = [...t0, ...t1, ...t2, ...t3, ...t4, ...t5, ...b0, ...b1, ...b5, ...dests, ...cats];
+  const byId: Record<string, FlowNode> = {};
+  allNodes.forEach(n => { if (!byId[n.id]) byId[n.id] = n; });
+
+  // Map column key → current node array (for drag midpoint computation)
+  const colNodeMap: Record<string, FlowNode[]> = { t1, t2, t3, t4, dests };
+  if (cats.length) colNodeMap.cats = cats;
+
+  function getSvgY(clientY: number): number {
+    if (!svgRef.current) return 0;
+    const rect = svgRef.current.getBoundingClientRect();
+    return (clientY - rect.top) / rect.height * H;
+  }
+
+  function handleNodeMouseDown(colKey: string, nodeId: string, e: React.MouseEvent) {
+    e.preventDefault();
+    setDragging({ colKey, nodeId });
+  }
+
+  function handleSvgMouseMove(e: React.MouseEvent) {
+    if (!dragging) return;
+    const y = getSvgY(e.clientY);
+    const nodes = colNodeMap[dragging.colKey];
+    if (!nodes) return;
+    const def = draggableCols[dragging.colKey];
+    const currentOrder = getOrder(dragging.colKey, def?.defaults ?? []);
+    const dragIdx = currentOrder.indexOf(dragging.nodeId);
+    // Find which slot the mouse is over (based on node midpoints in current order)
+    let newIdx = nodes.length - 1;
+    for (let i = 0; i < nodes.length; i++) {
+      if (y < nodes[i].y + nodes[i].h / 2) { newIdx = i; break; }
+    }
+    if (newIdx !== dragIdx && newIdx >= 0 && newIdx < currentOrder.length) {
+      const next = [...currentOrder];
+      next.splice(dragIdx, 1);
+      next.splice(newIdx, 0, dragging.nodeId);
+      setColOrders(prev => ({ ...prev, [dragging.colKey]: next }));
+    }
+  }
+
+  const links: LinkDef[] = [
+    { from: "biz_rev", to: "biz_costs", value: bizCostTotal, color: COL.COST },
+    { from: "biz_rev", to: "gross_sal", value: grossSalary, color: COL.ASHTON },
+    { from: "biz_rev", to: "pre_profit", value: Math.max(0, preTaxProfit), color: COL.BIZ },
+    { from: "gross_sal", to: "sal_tax", value: salaryTax, color: COL.TAX },
+    { from: "gross_sal", to: "net_sal", value: netSalary, color: COL.ASHTON },
+    { from: "pre_profit", to: "corp_tax", value: corpTax, color: COL.TAX },
+    { from: "pre_profit", to: "after_corp", value: Math.max(0, afterCorp), color: COL.BIZ },
+    { from: "after_corp", to: "div_gross", value: dividendGross, color: COL.ASHTON },
+    { from: "after_corp", to: "retained", value: Math.max(0, retained), color: COL.SAVE },
+    { from: "div_gross", to: "div_tax", value: dividendTax, color: COL.TAX },
+    { from: "div_gross", to: "div_net", value: dividendNet, color: COL.ASHTON },
+    { from: "net_sal", to: "a_pool", value: netSalary, color: COL.ASHTON },
+    { from: "div_net", to: "a_pool", value: dividendNet, color: COL.ASHTON },
+    { from: "m_gross", to: "m_tax", value: mTax, color: COL.TAX },
+    { from: "m_gross", to: "m_net", value: mNet, color: COL.MARIA },
+    { from: "m_net", to: "m_pool", value: mNet, color: COL.MARIA },
+    { from: "a_pool", to: "joint", value: aJointShare, color: COL.JOINT },
+    { from: "a_pool", to: "a_pers", value: aPersonal, color: COL.COST },
+    { from: "a_pool", to: "a_save", value: aLeftover, color: COL.SAVE },
+    { from: "m_pool", to: "joint", value: mJointShare, color: COL.JOINT },
+    { from: "m_pool", to: "m_pers", value: mPersonal, color: COL.COST },
+    { from: "m_pool", to: "m_save", value: mLeftover, color: COL.SAVE },
+  ];
+
+  if (byCategory) {
+    cats.forEach(cat => {
+      const src = cat.sources || {};
+      // Single merged link for joint (avoids duplicate ribbons)
+      if ((src.joint || 0) > 0) {
+        links.push({ from: "joint", to: cat.id, value: src.joint || 0, color: cat.color });
+      }
+      if ((src.a_pers || 0) > 0) links.push({ from: "a_pers", to: cat.id, value: src.a_pers, color: cat.color });
+      if ((src.m_pers || 0) > 0) links.push({ from: "m_pers", to: cat.id, value: src.m_pers, color: cat.color });
+      if ((src.a_save || 0) > 0) links.push({ from: "a_save", to: cat.id, value: src.a_save, color: cat.color });
+      if ((src.m_save || 0) > 0) links.push({ from: "m_save", to: cat.id, value: src.m_save, color: cat.color });
+    });
+  }
+
+  // --- Sorted-offset algorithm to minimise ribbon crossings ---
+  const validLinks = links.filter(l => l.value > 0 && byId[l.from] && byId[l.to]);
+
+  const srcGroups: Record<string, LinkDef[]> = {};
+  const dstGroups: Record<string, LinkDef[]> = {};
+  validLinks.forEach(l => {
+    (srcGroups[l.from] ??= []).push(l);
+    (dstGroups[l.to] ??= []).push(l);
+  });
+
+  // Sort each source group by destination centre y (barycenter) — top to bottom
+  Object.values(srcGroups).forEach(g =>
+    g.sort((a, b) => (byId[a.to].y + byId[a.to].h / 2) - (byId[b.to].y + byId[b.to].h / 2))
+  );
+  // Sort each dest group by source centre y — top to bottom
+  Object.values(dstGroups).forEach(g =>
+    g.sort((a, b) => (byId[a.from].y + byId[a.from].h / 2) - (byId[b.from].y + byId[b.from].h / 2))
+  );
+
+  // Assign source offsets (in source-sorted order)
+  const srcOff: Record<string, number> = {};
+  const linkMeta = new Map<LinkDef, { sY: number; dY: number; h: number }>();
+
+  Object.values(srcGroups).forEach(g => {
+    g.forEach(l => {
+      const h = vScale(l.value);
+      if (srcOff[l.from] === undefined) srcOff[l.from] = 0;
+      linkMeta.set(l, { sY: byId[l.from].y + srcOff[l.from], dY: 0, h });
+      srcOff[l.from] += h;
+    });
+  });
+
+  // Assign dest offsets (in dest-sorted order)
+  const dstOff: Record<string, number> = {};
+  Object.values(dstGroups).forEach(g => {
+    g.forEach(l => {
+      const meta = linkMeta.get(l);
+      if (!meta) return;
+      if (dstOff[l.to] === undefined) dstOff[l.to] = 0;
+      meta.dY = byId[l.to].y + dstOff[l.to];
+      dstOff[l.to] += meta.h;
+    });
+  });
+
+  // Build ribbon objects
+  const ribbons = validLinks.map(l => {
+    const meta = linkMeta.get(l);
+    if (!meta) return null;
+    const { sY, dY, h } = meta;
+    const x0 = byId[l.from].x + nodeW;
+    const x1 = byId[l.to].x;
+    const mx = (x0 + x1) / 2;
+    const path = `M ${x0},${sY} C ${mx},${sY} ${mx},${dY} ${x1},${dY} L ${x1},${dY + h} C ${mx},${dY + h} ${mx},${sY + h} ${x0},${sY + h} Z`;
+    return {
+      path, color: l.color, from: l.from, to: l.to, value: l.value,
+      centerX: (x0 + x1) / 2,
+      centerY: (sY + dY) / 2 + h / 2,
+    };
+  }).filter((x): x is NonNullable<typeof x> => Boolean(x));
+
+  // Find which draggable column (if any) contains this node
+  const nodeColKey = (nodeId: string) =>
+    Object.entries(draggableCols).find(([, def]) => def.defaults.includes(nodeId))?.[0] ?? null;
+
+  const renderNode = (n: FlowNode) => {
+    const labelX = n.x + nodeW + 10;
+    const labelY = n.y + n.h / 2;
+    const labelText = n.label;
+    const amtText = `€${Math.round(n.value).toLocaleString()}`;
+    const labelW = Math.max(labelText.length * 7.2, amtText.length * 7.5) + 16;
+    const labelH = 30;
+    const colKey = nodeColKey(n.id);
+    const isDraggable = colKey !== null;
+    const isDragging = dragging?.nodeId === n.id;
+
+    return (
+      <g key={n.id}>
+        <rect x={n.x} y={n.y} width={nodeW} height={n.h} fill={n.color} rx={1}
+          style={{ cursor: isDraggable ? (isDragging ? "grabbing" : "grab") : "default" }}
+          opacity={isDragging ? 0.5 : 1}
+          onMouseDown={isDraggable && colKey ? (e) => handleNodeMouseDown(colKey, n.id, e) : undefined}
+        />
+        <rect x={labelX - 2} y={labelY - labelH / 2}
+          width={labelW} height={labelH}
+          fill="var(--paper)" stroke="var(--rule-soft)" strokeWidth={0.5}
+          rx={2} opacity={0.96} />
+        <text x={labelX + 6} y={labelY - 3}
+          style={{ fontFamily: "var(--serif)", fontSize: 12.5, fill: "var(--ink)", fontWeight: 500 }}>
+          {labelText}
+        </text>
+        <text x={labelX + 6} y={labelY + 11}
+          style={{ fontFamily: "var(--mono)", fontSize: 10.5, fill: n.color, fontWeight: 600 }}>
+          {amtText}
+        </text>
+      </g>
+    );
+  };
+
+  const headerLabels = [
+    { x: col[0], label: "SOURCE" },
+    { x: col[1], label: "BIZ STAGES" },
+    { x: col[2], label: "FIRST TAX GATES" },
+    { x: col[3], label: "PROFIT SPLIT" },
+    { x: col[4], label: "DIVIDEND TAX" },
+    { x: col[5], label: "SPENDABLE" },
+    { x: destX, label: "DESTINATION" },
+  ];
+  if (byCategory) headerLabels.push({ x: catX, label: "CATEGORY" });
+
+  const svgW = byCategory ? W + 400 : W + 140;
+
+  return (
+    <svg ref={svgRef} className="chart" viewBox={`0 0 ${svgW} ${H}`}
+      style={{ maxWidth: "100%", cursor: dragging ? "grabbing" : undefined }}
+      onMouseMove={handleSvgMouseMove}
+      onMouseUp={() => setDragging(null)}
+      onMouseLeave={() => setDragging(null)}>
+      {headerLabels.map((h, i) => (
+        <text key={i} x={h.x} y={pad + 10}
+          style={{ fontFamily: "var(--mono)", fontSize: 10.5, letterSpacing: "0.14em", fill: "var(--ink-3)" }}>
+          {h.label}
+        </text>
+      ))}
+      <line x1={pad} y1={botY - 10} x2={destX + 20} y2={botY - 10}
+        stroke="var(--rule-soft)" strokeDasharray="3 3" />
+      <text x={pad + 4} y={botY - 14}
+        style={{ fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.14em", fill: "var(--ink-3)" }}>
+        ASHTON&apos;S OY STREAM
+      </text>
+      <text x={pad + 4} y={botY + 12}
+        style={{ fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.14em", fill: "var(--ink-3)" }}>
+        MARIA SALARY STREAM
+      </text>
+
+      {ribbons.map((r, i) => (
+        <path key={i} d={r.path} fill={r.color}
+          opacity={hovered && hovered.from === r.from && hovered.to === r.to ? 0.75 : 0.35}
+          style={{ cursor: "pointer" }}
+          onMouseEnter={() => setHovered({ from: r.from, to: r.to, value: r.value, color: r.color, x: r.centerX, y: r.centerY })}
+          onMouseLeave={() => setHovered(null)}
+        />
+      ))}
+
+      {Object.values(byId).map(renderNode)}
+
+      {hovered && (() => {
+        const fromNode = byId[hovered.from];
+        const toNode = byId[hovered.to];
+        const tx = Math.min(hovered.x, svgW - 210);
+        const ty = Math.max(hovered.y - 30, topY);
+        return (
+          <g>
+            <rect x={tx} y={ty} width={200} height={52} fill="var(--paper)" stroke="var(--rule)" strokeWidth={1} rx={2} opacity={0.97} />
+            <text x={tx + 8} y={ty + 15} style={{ fontFamily: "var(--serif)", fontSize: 11, fill: "var(--ink)" }}>
+              {fromNode?.label ?? hovered.from} → {toNode?.label ?? hovered.to}
+            </text>
+            <text x={tx + 8} y={ty + 30} style={{ fontFamily: "var(--mono)", fontSize: 12, fill: hovered.color, fontWeight: 600 }}>
+              €{Math.round(hovered.value).toLocaleString()}
+            </text>
+            <text x={tx + 8} y={ty + 44} style={{ fontFamily: "var(--italic)", fontStyle: "italic", fontSize: 10, fill: "var(--ink-3)" }}>
+              {((hovered.value / total) * 100).toFixed(1)}% of total inflow
+            </text>
+          </g>
+        );
+      })()}
+    </svg>
+  );
+}

--- a/app/pages/ledger/screens/Inputs.tsx
+++ b/app/pages/ledger/screens/Inputs.tsx
@@ -1,0 +1,680 @@
+import { Fragment, useState } from "react";
+import { Bar, EditableCell, Folio, Panel, Segmented, Smallcaps, Stat, Who } from "../primitives.js";
+import { BUSINESS, CATEGORIES, SETTINGS, deriveBiz, fmt, fx } from "../data.js";
+import type { Derived, LedgerState } from "../state.js";
+import type { Iou, IouEntry, SplitMode, Asset, Debt } from "../data.js";
+
+type InputsSection = "income" | "joint" | "personal" | "business" | "tax" | "assets" | "ious" | "split";
+
+export function Inputs({ state, d }: { state: LedgerState; d: Derived }) {
+  const [section, setSection] = useState<InputsSection>("income");
+
+  return (
+    <>
+      <Folio section="Section IV" title="Inputs" no="IV"
+        dek="The one place where the numbers live. Edit here; the whole book updates." />
+
+      <div className="content">
+        <div className="panel ruled" style={{ padding: "10px 14px" }}>
+          <Segmented<InputsSection>
+            value={section}
+            onChange={setSection}
+            options={[
+              { value: "income",   label: "Income" },
+              { value: "joint",    label: "Joint expenses" },
+              { value: "personal", label: "Personal spending" },
+              { value: "business", label: "Business" },
+              { value: "tax",      label: "Tax rates" },
+              { value: "assets",   label: "Assets & debts" },
+              { value: "ious",     label: "IOUs" },
+              { value: "split",    label: "Split rules" },
+            ]}
+          />
+        </div>
+
+        {section === "income"   && <IncomeSection state={state} />}
+        {section === "joint"    && <JointSection state={state} />}
+        {section === "personal" && <PersonalSection state={state} />}
+        {section === "business" && <BusinessSection state={state} />}
+        {section === "tax"      && <TaxSection state={state} />}
+        {section === "assets"   && <AssetsSection state={state} />}
+        {section === "ious"     && <IousSection state={state} />}
+        {section === "split"    && <SplitSection state={state} d={d} />}
+      </div>
+    </>
+  );
+}
+
+function IncomeSection({ state }: { state: LedgerState }) {
+  const { income, setIncome, tax } = state;
+  const [ashtonMode, setAshtonMode] = useState<"net" | "gross">("net");
+  const [mariaMode, setMariaMode] = useState<"net" | "gross">("net");
+
+  // Gross salary field for Ashton (separate from business salary)
+  const [ashtonGrossDraft, setAshtonGrossDraft] = useState<number>(
+    Math.round(income.ashton.salary / (1 - tax.salaryTaxRate))
+  );
+  const [mariaGrossDraft, setMariaGrossDraft] = useState<number>(income.partner.gross || income.partner.total);
+
+  const update = (person: "ashton" | "partner", key: string, v: number) => {
+    setIncome(i => {
+      const next = { ...i, [person]: { ...i[person], [key]: v } };
+      next.ashton.total = (next.ashton.salary || 0) + (next.ashton.dividend || 0);
+      next.partner.total = next.partner.salary || 0;
+      return next;
+    });
+  };
+
+  const applyAshtonGross = (gross: number) => {
+    const netSalary = gross * (1 - tax.salaryTaxRate);
+    setAshtonGrossDraft(gross);
+    update("ashton", "salary", Math.round(netSalary * 100) / 100);
+  };
+
+  const applyMariaGross = (gross: number) => {
+    const netSalary = gross * (1 - tax.mariaTaxRate);
+    setMariaGrossDraft(gross);
+    update("partner", "gross", gross);
+    update("partner", "salary", Math.round(netSalary * 100) / 100);
+  };
+
+  const ModeToggle = ({ mode, setMode }: { mode: "net" | "gross"; setMode: (m: "net" | "gross") => void }) => (
+    <span style={{ display: "flex", gap: 0, border: "1px solid var(--rule-soft)", fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.1em" }}>
+      <button onClick={() => setMode("net")} style={{ padding: "2px 7px", background: mode === "net" ? "var(--ink)" : "transparent", color: mode === "net" ? "var(--paper)" : "var(--ink-3)", border: "none" }}>NET</button>
+      <button onClick={() => setMode("gross")} style={{ padding: "2px 7px", background: mode === "gross" ? "var(--ink)" : "transparent", color: mode === "gross" ? "var(--paper)" : "var(--ink-3)", border: "none" }}>GROSS</button>
+    </span>
+  );
+
+  return (
+    <div className="grid g-2">
+      <Panel
+        title="Ashton — income (before personal tax)"
+        meta="monthly · EUR · see Tax rates for gates"
+        action={<ModeToggle mode={ashtonMode} setMode={setAshtonMode} />}
+      >
+        <table className="table">
+          <tbody>
+            {ashtonMode === "gross" ? (
+              <>
+                <tr>
+                  <td>Gross salary (before withholding)</td>
+                  <EditableCell value={ashtonGrossDraft} onChange={applyAshtonGross} prefix="€" />
+                </tr>
+                <tr>
+                  <td className="italic" style={{ paddingLeft: 20, fontSize: 11, color: "var(--ink-3)" }}>
+                    − salary tax ({(tax.salaryTaxRate * 100).toFixed(1)}%)
+                  </td>
+                  <td className="num neg" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+                    −€{Math.round(ashtonGrossDraft * tax.salaryTaxRate).toLocaleString()}
+                  </td>
+                </tr>
+                <tr className="subtotal">
+                  <td>= Net salary (computed)</td>
+                  <td className="num">€{Math.round(ashtonGrossDraft * (1 - tax.salaryTaxRate)).toLocaleString()}</td>
+                </tr>
+              </>
+            ) : (
+              <tr><td>Net salary (from Oy)</td><EditableCell value={income.ashton.salary} onChange={v => update("ashton", "salary", v)} prefix="€" /></tr>
+            )}
+            <tr><td>Dividend (declared, gross)</td><EditableCell value={income.ashton.dividend} onChange={v => update("ashton", "dividend", v)} prefix="€" /></tr>
+            <tr className="total"><td>Combined</td><td className="num">€{(income.ashton.salary + income.ashton.dividend).toLocaleString()}</td></tr>
+            <tr><td className="italic" style={{ fontSize: 11, color: "var(--ink-3)" }}>minus dividend tax ({(tax.dividendTaxRate * 100).toFixed(1)}%)</td>
+              <td className="num neg" style={{ fontSize: 11, color: "var(--ink-3)" }}>−€{Math.round(income.ashton.dividend * tax.dividendTaxRate).toLocaleString()}</td></tr>
+            <tr className="subtotal"><td>Ashton actual take-home</td>
+              <td className="num">€{Math.round(income.ashton.salary + income.ashton.dividend * (1 - tax.dividendTaxRate)).toLocaleString()}</td></tr>
+          </tbody>
+        </table>
+      </Panel>
+      <Panel
+        title="Maria — income"
+        meta="monthly · EUR"
+        action={<ModeToggle mode={mariaMode} setMode={setMariaMode} />}
+      >
+        <table className="table">
+          <tbody>
+            {mariaMode === "gross" ? (
+              <>
+                <tr>
+                  <td>Gross salary</td>
+                  <EditableCell value={mariaGrossDraft} onChange={applyMariaGross} prefix="€" />
+                </tr>
+                <tr>
+                  <td className="italic" style={{ paddingLeft: 20, fontSize: 11, color: "var(--ink-3)" }}>
+                    − income tax ({(tax.mariaTaxRate * 100).toFixed(1)}%)
+                  </td>
+                  <td className="num neg" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+                    −€{Math.round(mariaGrossDraft * tax.mariaTaxRate).toLocaleString()}
+                  </td>
+                </tr>
+                <tr className="subtotal">
+                  <td>= Net take-home (computed)</td>
+                  <td className="num">€{Math.round(mariaGrossDraft * (1 - tax.mariaTaxRate)).toLocaleString()}</td>
+                </tr>
+              </>
+            ) : (
+              <tr><td>Salary</td><EditableCell value={income.partner.salary} onChange={v => update("partner", "salary", v)} prefix="€" /></tr>
+            )}
+            <tr className="total"><td>Total</td><td className="num">€{income.partner.total.toLocaleString()}</td></tr>
+          </tbody>
+        </table>
+      </Panel>
+    </div>
+  );
+}
+
+function JointSection({ state }: { state: LedgerState }) {
+  const { joint, setJoint } = state;
+  const total = joint.reduce((s, x) => s + x.amt, 0);
+  const update = (id: string, v: number) => setJoint(js => js.map(j => j.id === id ? { ...j, amt: v } : j));
+  const add = () => setJoint(js => [...js, { id: `c${Date.now()}`, label: "New item", amt: 0, cat: "other" }]);
+  const updateLabel = (id: string, v: string) => setJoint(js => js.map(j => j.id === id ? { ...j, label: v } : j));
+  const remove = (id: string) => setJoint(js => js.filter(j => j.id !== id));
+
+  return (
+    <Panel title="Joint expenses" meta={`${joint.length} items · €${Math.round(total).toLocaleString()}/mo`}>
+      <table className="table">
+        <thead>
+          <tr><th>Item</th><th>Category</th><th className="num">Monthly</th><th className="num">Yearly</th><th></th></tr>
+        </thead>
+        <tbody>
+          {joint.map(j => (
+            <tr key={j.id}>
+              <td>
+                <input className="cell-input" value={j.label}
+                  onChange={e => updateLabel(j.id!, e.target.value)}
+                  style={{ minWidth: 200 }} />
+              </td>
+              <td><span className="pill">{j.cat}</span></td>
+              <EditableCell value={j.amt} onChange={v => update(j.id!, v)} prefix="€" />
+              <td className="num italic" style={{ color: "var(--ink-3)" }}>€{(j.amt * 12).toLocaleString()}</td>
+              <td><button onClick={() => remove(j.id!)} style={{ color: "var(--ink-3)" }}>×</button></td>
+            </tr>
+          ))}
+          <tr className="total">
+            <td colSpan={2}>Total</td>
+            <td className="num">€{Math.round(total).toLocaleString()}</td>
+            <td className="num">€{Math.round(total * 12).toLocaleString()}</td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+      <button className="btn mt-md" onClick={add}>+ Add joint expense</button>
+    </Panel>
+  );
+}
+
+function PersonalSection({ state }: { state: LedgerState }) {
+  const { ashtonP, setAshtonP, mariaP, setMariaP } = state;
+  return (
+    <div className="grid g-2">
+      <PersonalList title="Ashton — personal" list={ashtonP} setList={setAshtonP} />
+      <PersonalList title="Maria — personal" list={mariaP} setList={setMariaP} />
+    </div>
+  );
+}
+
+function PersonalList({ title, list, setList }: { title: string; list: LedgerState["ashtonP"]; setList: LedgerState["setAshtonP"] }) {
+  const total = list.reduce((s, x) => s + x.amt, 0);
+  const update = (i: number, v: number) => setList(xs => xs.map((x, j) => j === i ? { ...x, amt: v } : x));
+  const updateLabel = (i: number, v: string) => setList(xs => xs.map((x, j) => j === i ? { ...x, label: v } : x));
+  const add = () => setList(xs => [...xs, { label: "New item", amt: 0 }]);
+  const remove = (i: number) => setList(xs => xs.filter((_, j) => j !== i));
+  return (
+    <Panel title={title} meta={`${list.length} · €${Math.round(total).toLocaleString()}/mo`}>
+      <table className="table">
+        <tbody>
+          {list.map((it, i) => (
+            <tr key={i}>
+              <td>
+                <input className="cell-input" value={it.label}
+                  onChange={e => updateLabel(i, e.target.value)} />
+              </td>
+              <EditableCell value={it.amt} onChange={v => update(i, v)} prefix="€" />
+              <td><button onClick={() => remove(i)} style={{ color: "var(--ink-3)" }}>×</button></td>
+            </tr>
+          ))}
+          <tr className="total">
+            <td>Total</td>
+            <td className="num">€{Math.round(total).toLocaleString()}</td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+      <button className="btn mt-md" onClick={add}>+ Add</button>
+    </Panel>
+  );
+}
+
+function BusinessSection({ state }: { state: LedgerState }) {
+  const { bizRevenue, setBizRevenue, bizCosts, setBizCosts } = state;
+  const total = bizCosts.reduce((s, c) => s + c.amt, 0);
+  const net = bizRevenue - total;
+  const update = (i: number, v: number) => setBizCosts(xs => xs.map((x, j) => j === i ? { ...x, amt: v } : x));
+  const updateLabel = (i: number, v: string) => setBizCosts(xs => xs.map((x, j) => j === i ? { ...x, label: v } : x));
+  const add = () => setBizCosts(xs => [...xs, { label: "New cost", amt: 0 }]);
+  const remove = (i: number) => setBizCosts(xs => xs.filter((_, j) => j !== i));
+
+  return (
+    <div className="grid g-2-1">
+      <Panel title="Business costs" meta={`${bizCosts.length} · €${Math.round(total).toLocaleString()}/mo`}>
+        <table className="table">
+          <tbody>
+            {bizCosts.map((c, i) => (
+              <tr key={i}>
+                <td>
+                  <input className="cell-input" value={c.label}
+                    onChange={e => updateLabel(i, e.target.value)} />
+                </td>
+                <EditableCell value={c.amt} onChange={v => update(i, v)} prefix="€" />
+                <td className="num italic" style={{ color: "var(--ink-3)" }}>€{(c.amt * 12).toLocaleString()}</td>
+                <td><button onClick={() => remove(i)} style={{ color: "var(--ink-3)" }}>×</button></td>
+              </tr>
+            ))}
+            <tr className="total">
+              <td>Total</td>
+              <td className="num">€{Math.round(total).toLocaleString()}</td>
+              <td className="num">€{Math.round(total * 12).toLocaleString()}</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <button className="btn mt-md" onClick={add}>+ Add business cost</button>
+      </Panel>
+      <Panel title="Revenue & summary">
+        <table className="table">
+          <tbody>
+            <tr><td>Monthly revenue</td><EditableCell value={bizRevenue} onChange={setBizRevenue} prefix="€" /></tr>
+            <tr><td>Costs</td><td className="num neg">−€{Math.round(total).toLocaleString()}</td></tr>
+            <tr className="subtotal"><td>Pre-tax net</td><td className="num">€{Math.round(net).toLocaleString()}</td></tr>
+            <tr><td>Corporate tax (~20%)</td><td className="num neg">−€{Math.round(net * 0.20).toLocaleString()}</td></tr>
+            <tr className="total"><td>After tax</td><td className="num">€{Math.round(net * 0.80).toLocaleString()}</td></tr>
+          </tbody>
+        </table>
+      </Panel>
+    </div>
+  );
+}
+
+function AssetsSection({ state }: { state: LedgerState }) {
+  const { assets, setAssets, debts, setDebts } = state;
+  const total = assets.reduce((s, a) => s + a.bal * fx[a.cur], 0);
+  const totalDebt = debts.reduce((s, d) => s + d.bal * fx[d.cur], 0);
+  const upd = (id: string, v: number) => setAssets(as => as.map(a => a.id === id ? { ...a, bal: v } : a));
+  const updLabel = (id: string, v: string) => setAssets(as => as.map(a => a.id === id ? { ...a, label: v } : a));
+  const rem = (id: string) => setAssets(as => as.filter(a => a.id !== id));
+  const add = () => setAssets(as => [...as, { id: `a${Date.now()}`, label: "New account", type: "cash", scope: "personal", owner: "ashton", cur: "EUR", bal: 0, apy: 0 }]);
+
+  const updDebt = (id: string, v: number) => setDebts(ds => ds.map(d => d.id === id ? { ...d, bal: v } : d));
+  const updDebtLabel = (id: string, v: string) => setDebts(ds => ds.map(d => d.id === id ? { ...d, label: v } : d));
+  const remDebt = (id: string) => setDebts(ds => ds.filter(d => d.id !== id));
+  const addDebt = () => setDebts(ds => [...ds, { id: `d${Date.now()}`, label: "New debt", owner: "ashton", bal: 0, cur: "EUR", rate: 0 }]);
+
+  const updateScope = (id: string, scope: Asset["scope"]) => setAssets(as => as.map(a => a.id === id ? { ...a, scope } : a));
+  const updateType = (id: string, type: Asset["type"]) => setAssets(as => as.map(a => a.id === id ? { ...a, type } : a));
+  const updateCur = (id: string, cur: string) => setAssets(as => as.map(a => a.id === id ? { ...a, cur } : a));
+
+  return (
+    <>
+      <Panel title="Assets" meta={`${assets.length} accounts · €${Math.round(total).toLocaleString()} total`}>
+        <table className="table">
+          <thead>
+            <tr><th>Account</th><th>Scope</th><th>Type</th><th>Cur</th><th className="num">Balance</th><th className="num">EUR</th><th></th></tr>
+          </thead>
+          <tbody>
+            {assets.map(a => (
+              <tr key={a.id}>
+                <td><input className="cell-input" value={a.label} onChange={e => updLabel(a.id, e.target.value)} /></td>
+                <td>
+                  <select value={a.scope} onChange={e => updateScope(a.id, e.target.value as Asset["scope"])} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+                    <option value="personal">personal</option>
+                    <option value="business">business</option>
+                  </select>
+                </td>
+                <td>
+                  <select value={a.type} onChange={e => updateType(a.id, e.target.value as Asset["type"])} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+                    <option value="cash">cash</option>
+                    <option value="hysa">hysa</option>
+                    <option value="brokerage">brokerage</option>
+                    <option value="receivable">receivable</option>
+                    <option value="pension">pension</option>
+                  </select>
+                </td>
+                <td>
+                  <select value={a.cur} onChange={e => updateCur(a.id, e.target.value)} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+                    <option value="EUR">EUR</option>
+                    <option value="USD">USD</option>
+                    <option value="CAD">CAD</option>
+                    <option value="GBP">GBP</option>
+                  </select>
+                </td>
+                <EditableCell value={a.bal} onChange={v => upd(a.id, v)} prefix={a.cur === "CAD" ? "C$" : a.cur === "USD" ? "$" : a.cur === "GBP" ? "£" : "€"} />
+                <td className="num italic" style={{ color: "var(--ink-3)" }}>€{Math.round(a.bal * fx[a.cur]).toLocaleString()}</td>
+                <td><button onClick={() => rem(a.id)} style={{ color: "var(--ink-3)" }}>×</button></td>
+              </tr>
+            ))}
+            <tr className="total">
+              <td colSpan={5}>Total</td>
+              <td className="num">€{Math.round(total).toLocaleString()}</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <button className="btn mt-md" onClick={add}>+ Add account</button>
+      </Panel>
+
+      <Panel title="Debts" meta={`${debts.length} · €${Math.round(totalDebt).toLocaleString()} outstanding`}>
+        <table className="table">
+          <thead>
+            <tr><th>Debt</th><th>Cur</th><th className="num">Balance</th><th className="num">Rate</th><th className="num">Annual interest</th><th></th></tr>
+          </thead>
+          <tbody>
+            {debts.map(debt => (
+              <tr key={debt.id}>
+                <td><input className="cell-input" value={debt.label} onChange={e => updDebtLabel(debt.id, e.target.value)} /></td>
+                <td className="mono" style={{ fontSize: 10 }}>{debt.cur}</td>
+                <EditableCell value={debt.bal} onChange={v => updDebt(debt.id, v)} prefix={debt.cur === "CAD" ? "C$" : "€"} />
+                <td className="num">{(debt.rate * 100).toFixed(2)}%</td>
+                <td className="num neg">−€{Math.round(debt.bal * fx[debt.cur] * debt.rate).toLocaleString()}</td>
+                <td><button onClick={() => remDebt(debt.id)} style={{ color: "var(--ink-3)" }}>×</button></td>
+              </tr>
+            ))}
+            <tr className="total">
+              <td colSpan={2}>Total</td>
+              <td className="num">€{Math.round(totalDebt).toLocaleString()}</td>
+              <td></td>
+              <td className="num neg">−€{Math.round(debts.reduce((s, d) => s + d.bal * fx[d.cur] * d.rate, 0)).toLocaleString()}</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+        <button className="btn mt-md" onClick={addDebt}>+ Add debt</button>
+      </Panel>
+    </>
+  );
+}
+
+function IousSection({ state }: { state: LedgerState }) {
+  const { ious, setIous } = state;
+  const [open, setOpen] = useState<string | null>(null);
+
+  const add = () => setIous(is => [...is, { id: `i${Date.now()}`, counterparty: "New person",
+    direction: "incoming", cur: "EUR", principal: 0, paid: 0, note: "", history: [] }]);
+  const rem = (id: string) => setIous(is => is.filter(i => i.id !== id));
+  const upd = (id: string, k: keyof Iou, v: unknown) => setIous(is => is.map(i => i.id === id ? ({ ...i, [k]: v } as Iou) : i));
+  const addEntry = (id: string, entry: IouEntry) => setIous(is => is.map(i => {
+    if (i.id !== id) return i;
+    const h = [...(i.history || []), entry];
+    const paid = h.filter(x => x.kind === "repaid").reduce((s, x) => s + x.amt, 0);
+    const adj = h.filter(x => x.kind === "adjust").reduce((s, x) => s + x.amt, 0);
+    const lent = h.filter(x => x.kind === "lent" || x.kind === "borrowed").reduce((s, x) => s + x.amt, 0);
+    return { ...i, history: h, principal: lent + adj, paid };
+  }));
+
+  const incoming = ious.filter(i => i.direction === "incoming");
+  const outgoing = ious.filter(i => i.direction === "outgoing");
+  const incSum = incoming.reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
+  const outSum = outgoing.reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
+
+  const Row = ({ i }: { i: Iou }) => {
+    const outstanding = i.principal - i.paid;
+    const pct = i.principal ? (i.paid / i.principal * 100) : 0;
+    const isOpen = open === i.id;
+    return (
+      <Fragment>
+        <tr>
+          <td>
+            <input className="cell-input" value={i.counterparty}
+              onChange={e => upd(i.id, "counterparty", e.target.value)} />
+            {i.note && <div className="italic" style={{ fontSize: 11, color: "var(--ink-3)" }}>{i.note}</div>}
+          </td>
+          <td>
+            <select value={i.direction} onChange={e => upd(i.id, "direction", e.target.value)}
+              style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+              <option value="incoming">owes me</option>
+              <option value="outgoing">I owe</option>
+            </select>
+          </td>
+          <td className="mono" style={{ fontSize: 10 }}>{i.cur}</td>
+          <td className="num mono">{fmt(i.principal, i.cur, { decimals: 0 })}</td>
+          <td className="num mono pos">{fmt(i.paid, i.cur, { decimals: 0 })}</td>
+          <td className="num mono" style={{ fontWeight: 700 }}>{fmt(outstanding, i.cur, { decimals: 0 })}</td>
+          <td style={{ width: 120 }}><Bar pct={pct} variant={i.direction === "incoming" ? "moss" : "rust"} /></td>
+          <td className="num mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>{pct.toFixed(0)}%</td>
+          <td>
+            <button onClick={() => setOpen(isOpen ? null : i.id)} className="smallcaps">{isOpen ? "close" : "edit"}</button>
+            {" · "}
+            <button onClick={() => rem(i.id)} style={{ color: "var(--ink-3)" }}>×</button>
+          </td>
+        </tr>
+        {isOpen && (
+          <tr>
+            <td colSpan={9} style={{ background: "var(--paper-2)", padding: 14 }}>
+              <div className="flex-between" style={{ marginBottom: 10 }}>
+                <Smallcaps>Description / note</Smallcaps>
+              </div>
+              <input className="cell-input" value={i.note || ""}
+                placeholder="What is this IOU about? e.g. Rent apartment coverage, cat vet, splitting settlement…"
+                onChange={e => upd(i.id, "note", e.target.value)}
+                style={{ fontStyle: "italic", padding: "6px 8px", marginBottom: 14, border: "1px solid var(--rule-soft)", background: "var(--paper)" }} />
+
+              <Smallcaps>Ledger — {i.counterparty}</Smallcaps>
+              <table className="table mt-sm" style={{ background: "transparent" }}>
+                <thead><tr><th>Date</th><th>Label</th><th>Kind</th><th className="num">Amount ({i.cur})</th></tr></thead>
+                <tbody>
+                  {(i.history || []).map((h, idx) => (
+                    <tr key={idx}>
+                      <td className="mono" style={{ fontSize: 10 }}>{h.d}</td>
+                      <td>{h.label}</td>
+                      <td><span className="pill">{h.kind}</span></td>
+                      <td className={`num ${h.kind === "repaid" ? "pos" : ""}`}>
+                        {h.kind === "repaid" ? "+" : ""}{fmt(h.amt, i.cur, { decimals: 2 })}
+                      </td>
+                    </tr>
+                  ))}
+                  <NewEntryRow onAdd={(entry) => addEntry(i.id, entry)} direction={i.direction} />
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        )}
+      </Fragment>
+    );
+  };
+
+  return (
+    <Fragment>
+      <div className="grid g-3">
+        <Stat label="They owe me" value={incSum} size={32} showDec={false} sub={`${incoming.length} open · EUR equiv.`} />
+        <Stat label="I owe them" value={outSum} size={32} showDec={false} sub={`${outgoing.length} open · EUR equiv.`} />
+        <Stat label="Net position" value={incSum - outSum} size={32} showDec={false} sub="incoming − outgoing" />
+      </div>
+
+      <Panel title="Money owed between people" meta="click a row to see history">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Person</th><th>Direction</th><th>Cur</th>
+              <th className="num">Lent / borrowed</th>
+              <th className="num">Paid back</th>
+              <th className="num">Outstanding</th>
+              <th>Progress</th>
+              <th className="num">%</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {ious.map(i => <Row key={i.id} i={i} />)}
+          </tbody>
+        </table>
+        <button className="btn mt-md" onClick={add}>+ Add IOU</button>
+      </Panel>
+    </Fragment>
+  );
+}
+
+function NewEntryRow({ onAdd, direction }: { onAdd: (entry: IouEntry) => void; direction: Iou["direction"] }) {
+  const [d, setD] = useState(new Date().toISOString().slice(0, 10));
+  const [label, setLabel] = useState("");
+  const [amt, setAmt] = useState("");
+  const [kind, setKind] = useState<IouEntry["kind"]>("repaid");
+  return (
+    <tr>
+      <td><input className="cell-input mono" style={{ fontSize: 10 }} value={d} onChange={e => setD(e.target.value)} /></td>
+      <td><input className="cell-input" placeholder="Label" value={label} onChange={e => setLabel(e.target.value)} /></td>
+      <td>
+        <select value={kind} onChange={e => setKind(e.target.value as IouEntry["kind"])} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+          <option value="repaid">repaid</option>
+          <option value={direction === "incoming" ? "lent" : "borrowed"}>{direction === "incoming" ? "lent more" : "borrowed more"}</option>
+          <option value="adjust">adjust</option>
+        </select>
+      </td>
+      <td>
+        <div style={{ display: "flex", gap: 6 }}>
+          <input className="cell-input mono" placeholder="0.00" value={amt} onChange={e => setAmt(e.target.value)} style={{ textAlign: "right" }} />
+          <button className="btn" style={{ padding: "3px 8px", fontSize: 9 }} onClick={() => {
+            const n = parseFloat(amt);
+            if (!isNaN(n) && label) { onAdd({ d, label, amt: n, kind }); setLabel(""); setAmt(""); }
+          }}>add</button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function SplitSection({ state, d }: { state: LedgerState; d: Derived }) {
+  const { splitMode, setSplitMode } = state;
+  return (
+    <div className="grid g-2">
+      <Panel title="Split mode" meta="how joint expenses are divided">
+        <Segmented<SplitMode>
+          value={splitMode}
+          onChange={setSplitMode}
+          options={[
+            { value: "net",    label: "By net" },
+            { value: "gross",  label: "By gross" },
+            { value: "bizNet", label: "By biz-net" },
+            { value: "fifty",  label: "50 / 50" },
+            { value: "custom", label: "Custom" },
+          ]}
+        />
+        <div className="italic mt-md" style={{ fontSize: 13, color: "var(--ink-2)", textWrap: "pretty" as "pretty" }}>
+          {splitMode === "net"    && "Split joint expenses by net take-home share. Ashton pays more because his net salary + dividend is higher than Maria's net."}
+          {splitMode === "gross"  && "Split by pre-tax gross income — a fairer split when one partner pays a lot more tax."}
+          {splitMode === "bizNet" && "Split by what Ashton really earns including retained business profit. He'll pay the largest share because the Oy is growing equity in his name."}
+          {splitMode === "fifty"  && "Each partner pays half, regardless of income."}
+          {splitMode === "custom" && `Use a fixed ratio (currently Ashton ${(SETTINGS.ashtonPortionCustom * 100).toFixed(0)}%).`}
+        </div>
+      </Panel>
+      <Panel title="Current ratio" meta={splitMode === "fifty" ? "50 / 50" : "by income"}>
+        <table className="table">
+          <tbody>
+            <tr><td><Who who="ashton" label="Ashton" /></td><td className="num">€{Math.round(d.aIncome).toLocaleString()}</td><td className="num">{(d.aShare * 100).toFixed(2)}%</td></tr>
+            <tr><td><Who who="partner" label="Maria" /></td><td className="num">€{Math.round(d.mIncome).toLocaleString()}</td><td className="num">{(d.mShare * 100).toFixed(2)}%</td></tr>
+          </tbody>
+        </table>
+        <hr className="rule mt-md mb-md" />
+        <Smallcaps>Monthly joint share</Smallcaps>
+        <div className="mt-sm flex-between"><span>Ashton</span><span className="mono">€{Math.round(d.jointTotal * d.aShare).toLocaleString()}</span></div>
+        <div className="flex-between"><span>Maria</span><span className="mono">€{Math.round(d.jointTotal * d.mShare).toLocaleString()}</span></div>
+      </Panel>
+    </div>
+  );
+}
+
+function TaxSection({ state }: { state: LedgerState }) {
+  const { tax, setTax, bizRevenue, bizCosts, income } = state;
+  const upd = (k: keyof typeof tax, v: number) => setTax(t => ({ ...t, [k]: Math.max(0, Math.min(0.95, v)) }));
+
+  const biz = {
+    monthlyRevenue: bizRevenue, costs: bizCosts,
+    grossSalary: BUSINESS.grossSalary, dividendMonthly: income.ashton.dividend
+  };
+  const b = deriveBiz(biz, tax);
+  const mGross = income.partner.gross || income.partner.total;
+  const mTax = mGross * tax.mariaTaxRate;
+
+  const Row = ({ label, k, desc, derived }: { label: string; k: keyof typeof tax; desc: string; derived: string }) => (
+    <tr>
+      <td>
+        <div>{label}</div>
+        <div className="italic" style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 2 }}>{desc}</div>
+      </td>
+      <td style={{ width: 180 }}>
+        <div className="flex-between" style={{ gap: 8, alignItems: "center" }}>
+          <input type="range" min={0} max={0.6} step={0.001} value={tax[k]}
+            onChange={e => upd(k, parseFloat(e.target.value))}
+            style={{ flex: 1, accentColor: "var(--rust)" }} />
+        </div>
+      </td>
+      <td className="num mono" style={{ width: 80, fontWeight: 600 }}>
+        {(tax[k] * 100).toFixed(2)}%
+      </td>
+      <td className="num mono" style={{ fontSize: 11, color: "var(--ink-3)", width: 180 }}>{derived}</td>
+    </tr>
+  );
+
+  return (
+    <>
+      <Panel title="Tax rates" meta="separate gates for salary, corporate profit, and dividends">
+        <div className="italic mb-md" style={{ fontSize: 13, color: "var(--ink-2)", textWrap: "pretty" as "pretty", maxWidth: 680 }}>
+          Each rate taxes a different stream — salary is withheld by the Oy before it reaches Ashton,
+          corporate tax applies to pre-tax profit inside the Oy, and dividend tax is paid personally on declared dividends.
+          What survives each gate is what actually funds you.
+        </div>
+        <table className="table">
+          <thead>
+            <tr><th>Rate</th><th>Adjust</th><th className="num">Value</th><th className="num">Current monthly amount</th></tr>
+          </thead>
+          <tbody>
+            <Row k="salaryTaxRate" label="Salary tax (withholding)"
+              desc={`Paid by the Oy on Ashton's €${BUSINESS.grossSalary.toLocaleString()} gross salary. Goes directly to state — never enters Ashton's pocket.`}
+              derived={`−€${Math.round(b.salaryTax).toLocaleString()} of gross · net €${Math.round(b.netSalary).toLocaleString()}`} />
+            <Row k="corpTaxRate" label="Corporate tax"
+              desc={`Applied to the Oy's pre-tax profit (revenue − costs − gross salary). Finnish default 20%.`}
+              derived={`−€${Math.round(b.corpTax).toLocaleString()} of €${Math.round(b.preTaxProfit).toLocaleString()} profit · after-tax €${Math.round(b.afterCorp).toLocaleString()}`} />
+            <Row k="dividendTaxRate" label="Dividend tax (personal)"
+              desc={`Paid by Ashton personally on declared dividends. Finnish unlisted Oy dividends are partially tax-advantaged; 26.25% is a conservative blended rate above the acquisition-cost cap.`}
+              derived={`−€${Math.round(b.dividendTax).toLocaleString()} of €${Math.round(b.dividendGross).toLocaleString()} gross · net €${Math.round(b.dividendNet).toLocaleString()}`} />
+            <Row k="mariaTaxRate" label="Maria — income tax + social"
+              desc={`Applied to Maria's gross salary. Includes income tax and employee social contributions as a combined effective rate.`}
+              derived={`−€${Math.round(mTax).toLocaleString()} of €${Math.round(mGross).toLocaleString()} gross · net €${Math.round(mGross - mTax).toLocaleString()}`} />
+          </tbody>
+        </table>
+      </Panel>
+
+      <div className="grid g-2">
+        <Panel title="Ashton — total tax paid" meta="per month, across all three gates">
+          <table className="table">
+            <tbody>
+              <tr><td>Salary tax (via Oy)</td><td className="num neg">−€{Math.round(b.salaryTax).toLocaleString()}</td></tr>
+              <tr><td>Corporate tax (via Oy)</td><td className="num neg">−€{Math.round(b.corpTax).toLocaleString()}</td></tr>
+              <tr><td>Dividend tax (personal)</td><td className="num neg">−€{Math.round(b.dividendTax).toLocaleString()}</td></tr>
+              <tr className="total">
+                <td>Total</td>
+                <td className="num neg">−€{Math.round(b.salaryTax + b.corpTax + b.dividendTax).toLocaleString()}</td>
+              </tr>
+              <tr>
+                <td className="italic">Effective rate on €{bizRevenue.toLocaleString()} revenue</td>
+                <td className="num mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+                  {(((b.salaryTax + b.corpTax + b.dividendTax) / bizRevenue) * 100).toFixed(1)}%
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </Panel>
+
+        <Panel title="Where each stream ends up" meta="net to Ashton · net to state · retained">
+          <table className="table">
+            <tbody>
+              <tr><td>Ashton net salary</td><td className="num">€{Math.round(b.netSalary).toLocaleString()}</td></tr>
+              <tr><td>Ashton dividend (net)</td><td className="num">€{Math.round(b.dividendNet).toLocaleString()}</td></tr>
+              <tr className="subtotal"><td>→ Ashton pocket</td><td className="num">€{Math.round(b.netSalary + b.dividendNet).toLocaleString()}</td></tr>
+              <tr><td>Retained in Oy (equity)</td><td className="num pos">€{Math.round(b.retained).toLocaleString()}</td></tr>
+              <tr className="total"><td>→ State (all taxes)</td><td className="num neg">€{Math.round(b.salaryTax + b.corpTax + b.dividendTax).toLocaleString()}</td></tr>
+            </tbody>
+          </table>
+        </Panel>
+      </div>
+    </>
+  );
+}

--- a/app/pages/ledger/screens/Retirement.tsx
+++ b/app/pages/ledger/screens/Retirement.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { Folio, Panel, Smallcaps, Stat } from "../primitives.js";
+import type { Derived, LedgerState } from "../state.js";
+import type { PensionAccount } from "../data.js";
+
+const currentYear = 2026;
+const ashtonBirthYear = 1997;
+const mariaBirthYear = 1997;
+const retirementAge = 65;
+
+function yearsToRetirement(birthYear: number) {
+  return retirementAge - (currentYear - birthYear);
+}
+
+function projectBalance(bal: number, monthlyContrib: number, years: number, growthRate = 0.05): number {
+  let v = bal;
+  const mo = years * 12;
+  const r = growthRate / 12;
+  for (let i = 0; i < mo; i++) v = v * (1 + r) + monthlyContrib;
+  return v;
+}
+
+export function Retirement({ state, d }: { state: LedgerState; d: Derived }) {
+  const { pensions, setPensions } = state;
+  const [targetMonthlyIncome, setTargetMonthlyIncome] = useState(4000);
+  const [returnRate, setReturnRate] = useState(5);
+  const [inflationRate, setInflationRate] = useState(2);
+
+  const aYears = yearsToRetirement(ashtonBirthYear);
+  const mYears = yearsToRetirement(mariaBirthYear);
+
+  // FI number = 25x annual expenses (4% SWR)
+  const fiNumber = d.hhBurn * 12 * 25;
+  const fiProgress = d.totalAssets / fiNumber * 100;
+
+  // Project investable assets to retirement
+  const realReturn = (returnRate - inflationRate) / 100;
+  const monthlySaving = Math.max(0, d.hhSaving);
+  const projectedPortfolio = projectBalance(
+    d.brokerageAssets + d.liquidAssets,
+    monthlySaving,
+    aYears,
+    realReturn
+  );
+
+  // Pension projections
+  const upd = (id: string, k: keyof PensionAccount, v: unknown) =>
+    setPensions(ps => ps.map(p => p.id === id ? { ...p, [k]: v } : p));
+
+  const ashtonPensions = pensions.filter(p => p.owner === "ashton");
+  const mariaPensions = pensions.filter(p => p.owner === "partner");
+
+  const totalPensionBal = pensions.reduce((s, p) => s + p.currentBal, 0);
+
+  // SWR monthly income from portfolio at retirement
+  const swrMonthlyIncome = projectedPortfolio * 0.04 / 12;
+
+  // Pension income estimate
+  const aPensionMonthly = ashtonPensions.reduce((s, p) => s + p.projectedMonthlyAt65, 0);
+  const mPensionMonthly = mariaPensions.reduce((s, p) => s + p.projectedMonthlyAt65, 0);
+  const totalPensionMonthly = aPensionMonthly + mPensionMonthly;
+
+  const totalRetirementIncome = swrMonthlyIncome + totalPensionMonthly;
+  const retirementGap = targetMonthlyIncome - totalRetirementIncome;
+
+  return (
+    <>
+      <Folio section="Section V" title="Retirement" no="V"
+        dek="Pension accruals, FI number, and the long arc of savings compounding over time." />
+      <div className="content">
+
+        <div className="grid g-3">
+          <Stat label="FI number (25× annual burn)" value={fiNumber} size={38} showDec={false}
+            sub={`${fiProgress.toFixed(1)}% there · 4% withdrawal rule`} />
+          <Stat label="Projected portfolio at 65" value={projectedPortfolio} size={38} showDec={false}
+            sub={`at ${realReturn > 0 ? "+" : ""}${(realReturn * 100).toFixed(1)}% real return · €${Math.round(monthlySaving).toLocaleString()}/mo saved`} />
+          <Stat label="Est. monthly income at 65" value={totalRetirementIncome} size={38} showDec={false}
+            sub={`SWR €${Math.round(swrMonthlyIncome).toLocaleString()} + pension €${Math.round(totalPensionMonthly).toLocaleString()}`}
+          />
+        </div>
+
+        <Panel title="Assumptions" meta="adjust to model different futures">
+          <div className="grid g-3" style={{ gap: 20, padding: "4px 0" }}>
+            {[
+              { label: "Target monthly income at retirement", val: targetMonthlyIncome, set: setTargetMonthlyIncome, min: 1000, max: 15000, step: 100, fmt: (v: number) => `€${v.toLocaleString()}` },
+              { label: "Nominal portfolio return", val: returnRate, set: setReturnRate, min: 0, max: 12, step: 0.25, fmt: (v: number) => `${v.toFixed(2)}%` },
+              { label: "Inflation rate", val: inflationRate, set: setInflationRate, min: 0, max: 8, step: 0.25, fmt: (v: number) => `${v.toFixed(2)}%` },
+            ].map(({ label, val, set, min, max, step, fmt }) => (
+              <div key={label}>
+                <div className="flex-between mb-sm">
+                  <Smallcaps>{label}</Smallcaps>
+                  <span className="mono" style={{ fontSize: 12, fontWeight: 600 }}>{fmt(val)}</span>
+                </div>
+                <input type="range" min={min} max={max} step={step} value={val}
+                  onChange={e => set(parseFloat(e.target.value))}
+                  className="w-full" style={{ accentColor: "var(--rust)" }} />
+              </div>
+            ))}
+          </div>
+        </Panel>
+
+        <div className="grid g-2">
+          <Panel title="Income gap at retirement" meta="monthly, in today's money">
+            <table className="table">
+              <tbody>
+                <tr><td>Target monthly income</td><td className="num">€{targetMonthlyIncome.toLocaleString()}</td></tr>
+                <tr><td>Portfolio income (4% SWR)</td><td className="num pos">+€{Math.round(swrMonthlyIncome).toLocaleString()}</td></tr>
+                <tr><td>Pension income (estimated)</td><td className="num pos">+€{Math.round(totalPensionMonthly).toLocaleString()}</td></tr>
+                <tr className="total">
+                  <td>Gap / surplus</td>
+                  <td className={`num ${retirementGap <= 0 ? "pos" : "neg"}`}>
+                    {retirementGap <= 0 ? "+" : "−"}€{Math.abs(Math.round(retirementGap)).toLocaleString()}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div className="italic mt-md" style={{ fontSize: 12, color: "var(--ink-3)" }}>
+              {retirementGap <= 0
+                ? `Projections suggest you're on track. Portfolio alone covers target at ${(swrMonthlyIncome / targetMonthlyIncome * 100).toFixed(0)}%.`
+                : `Additional saving of €${Math.round(retirementGap / 0.04 * 12 / (aYears * 12)).toLocaleString()}/mo would close the gap.`}
+            </div>
+          </Panel>
+
+          <Panel title="Timeline" meta={`${aYears} years to 65`}>
+            <table className="table">
+              <tbody>
+                <tr><td>Ashton age now</td><td className="num">{currentYear - ashtonBirthYear}</td></tr>
+                <tr><td>Maria age now</td><td className="num">{currentYear - mariaBirthYear}</td></tr>
+                <tr><td>Target retirement age</td><td className="num">{retirementAge}</td></tr>
+                <tr><td>Years to Ashton&apos;s 65</td><td className="num">{aYears}</td></tr>
+                <tr className="subtotal"><td>Current investable assets</td><td className="num">€{Math.round(d.brokerageAssets + d.liquidAssets).toLocaleString()}</td></tr>
+                <tr><td>Current pension assets</td><td className="num">€{Math.round(totalPensionBal).toLocaleString()}</td></tr>
+                <tr className="total"><td>Total retirement-bound</td><td className="num">€{Math.round(d.brokerageAssets + d.liquidAssets + totalPensionBal).toLocaleString()}</td></tr>
+              </tbody>
+            </table>
+          </Panel>
+        </div>
+
+        <Panel title="Pension accounts" meta="click values to edit">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Account</th><th>Owner</th><th>Type</th>
+                <th className="num">Monthly contrib</th>
+                <th className="num">Current balance</th>
+                <th className="num">Est. mo. at 65</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pensions.map(p => (
+                <tr key={p.id}>
+                  <td>
+                    <input className="cell-input" value={p.label}
+                      onChange={e => upd(p.id, "label", e.target.value)} style={{ minWidth: 160 }} />
+                  </td>
+                  <td className="mono" style={{ fontSize: 10 }}>{p.owner}</td>
+                  <td><span className="pill">{p.type}</span></td>
+                  <td className="num">
+                    <input className="cell-input mono" value={p.monthlyContrib}
+                      onChange={e => upd(p.id, "monthlyContrib", parseFloat(e.target.value) || 0)}
+                      style={{ textAlign: "right", width: 70 }} />
+                  </td>
+                  <td className="num">
+                    <input className="cell-input mono" value={p.currentBal}
+                      onChange={e => upd(p.id, "currentBal", parseFloat(e.target.value) || 0)}
+                      style={{ textAlign: "right", width: 80 }} />
+                  </td>
+                  <td className="num">
+                    <input className="cell-input mono" value={p.projectedMonthlyAt65}
+                      onChange={e => upd(p.id, "projectedMonthlyAt65", parseFloat(e.target.value) || 0)}
+                      style={{ textAlign: "right", width: 70 }} />
+                  </td>
+                  <td style={{ fontSize: 11, color: "var(--ink-3)", fontStyle: "italic" }}>{p.note}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <button className="btn mt-md" onClick={() => setPensions(ps => [...ps, {
+            id: `p${Date.now()}`, label: "New pension", owner: "ashton", type: "private",
+            cur: "EUR", currentBal: 0, monthlyContrib: 0, accrualRatePct: 1.5, projectedMonthlyAt65: 0, note: "",
+          }])}>+ Add pension account</button>
+        </Panel>
+
+      </div>
+    </>
+  );
+}

--- a/app/pages/ledger/screens/Runway.tsx
+++ b/app/pages/ledger/screens/Runway.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useState } from "react";
+import { Bar, Folio, LedgerModal, Panel, Segmented, Smallcaps, Stat } from "../primitives.js";
+import { DepletionChart } from "../charts.js";
+import type { Derived, LedgerState } from "../state.js";
+import type { Scenario, ScenarioExpense } from "../data.js";
+
+type ModalKind = "new" | "rename" | null;
+type ExpenseTab = "joint" | "ashton" | "maria";
+
+export function Runway({ state, d }: { state: LedgerState; d: Derived }) {
+  const { scenarios, setScenarios } = state;
+  const [activeId, setActiveId] = useState<string>(scenarios[0].id);
+  const active: Scenario = scenarios.find(s => s.id === activeId) || scenarios[0];
+
+  const [modal, setModal] = useState<ModalKind>(null);
+  const [modalInput, setModalInput] = useState("");
+  const [expTab, setExpTab] = useState<ExpenseTab>("joint");
+
+  const openNew = () => { setModalInput(""); setModal("new"); };
+  const openRename = () => { setModalInput(active.name); setModal("rename"); };
+
+  const confirmModal = () => {
+    if (!modalInput.trim()) { setModal(null); return; }
+    if (modal === "new") {
+      const id = "c" + Date.now();
+      // New scenario starts as a copy of the current live spending inputs
+      setScenarios(s => [...s, {
+        id, name: modalInput.trim(), note: "",
+        partnerWorking: true, includeInvest: false, includeBusiness: false,
+        joint: state.joint.map(e => ({ id: e.id, label: e.label, amt: e.amt, cat: e.cat })),
+        ashtonP: state.ashtonP.map(e => ({ label: e.label, amt: e.amt, cat: e.cat })),
+        mariaP: state.mariaP.map(e => ({ label: e.label, amt: e.amt, cat: e.cat })),
+      }]);
+      setActiveId(id);
+    } else if (modal === "rename") {
+      setScenarios(s => s.map(x => x.id === activeId ? { ...x, name: modalInput.trim() } : x));
+    }
+    setModal(null);
+  };
+
+  const del = () => {
+    if (scenarios.length <= 1) return;
+    setScenarios(s => s.filter(x => x.id !== activeId));
+    setActiveId(scenarios[0].id);
+  };
+
+  // Helper to update a field on the active scenario
+  const updActive = <K extends keyof Scenario>(k: K, v: Scenario[K]) =>
+    setScenarios(s => s.map(x => x.id === activeId ? { ...x, [k]: v } : x));
+
+  // Expense editing helpers
+  const updExp = (tab: ExpenseTab, i: number, field: keyof ScenarioExpense, val: string | number) =>
+    setScenarios(s => s.map(x => {
+      if (x.id !== activeId) return x;
+      const key = tab === "joint" ? "joint" : tab === "ashton" ? "ashtonP" : "mariaP";
+      const arr = [...x[key]];
+      arr[i] = { ...arr[i], [field]: val };
+      return { ...x, [key]: arr };
+    }));
+
+  const addExp = (tab: ExpenseTab) =>
+    setScenarios(s => s.map(x => {
+      if (x.id !== activeId) return x;
+      const key = tab === "joint" ? "joint" : tab === "ashton" ? "ashtonP" : "mariaP";
+      return { ...x, [key]: [...x[key], { label: "New item", amt: 0, cat: "other" }] };
+    }));
+
+  const remExp = (tab: ExpenseTab, i: number) =>
+    setScenarios(s => s.map(x => {
+      if (x.id !== activeId) return x;
+      const key = tab === "joint" ? "joint" : tab === "ashton" ? "ashtonP" : "mariaP";
+      return { ...x, [key]: x[key].filter((_, j) => j !== i) };
+    }));
+
+  // Compute burn from this scenario's expense snapshot
+  const scenJoint = active.joint.reduce((s, e) => s + e.amt, 0);
+  const scenAshton = active.ashtonP.reduce((s, e) => s + e.amt, 0);
+  const scenMaria = active.mariaP.reduce((s, e) => s + e.amt, 0);
+  const scenBurn = scenJoint + scenAshton + scenMaria;
+  const partnerIncomeNet = active.partnerWorking ? d.mIncome : 0;
+  const netBurn = Math.max(100, scenBurn - partnerIncomeNet);
+
+  let pot = d.liquidAssets;
+  if (active.includeInvest) pot += d.brokerageAssets;
+  if (active.includeBusiness) pot += d.businessAssets;
+
+  const runway = Math.floor(pot / netBurn);
+
+  const currentList = expTab === "joint" ? active.joint
+    : expTab === "ashton" ? active.ashtonP
+    : active.mariaP;
+  const currentTotal = currentList.reduce((s, e) => s + e.amt, 0);
+
+  return (
+    <>
+      <Folio section="Section III" title="Runway" no="III"
+        dek="If the income stops, how long do the reserves last? Each scenario has its own expense snapshot." />
+
+      <div className="content">
+        <Panel title="Scenarios" meta={`${scenarios.length} saved`}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {scenarios.map(s => (
+              <button key={s.id} onClick={() => setActiveId(s.id)}
+                className={`chip ${s.id === activeId ? "on" : ""}`}
+                style={{
+                  padding: "6px 14px",
+                  background: s.id === activeId ? "var(--ink)" : "var(--paper-2)",
+                  color: s.id === activeId ? "var(--paper)" : "var(--ink)",
+                  border: "1px solid var(--rule)",
+                  fontFamily: "var(--mono)", fontSize: 11, cursor: "pointer",
+                }}>
+                {s.name}
+              </button>
+            ))}
+            <button onClick={openNew} className="chip"
+              style={{ padding: "6px 14px", background: "transparent", border: "1px dashed var(--rule)", fontFamily: "var(--mono)", fontSize: 11, cursor: "pointer" }}>
+              + new scenario
+            </button>
+          </div>
+          <div className="mt-md italic" style={{ fontSize: 13, color: "var(--ink-3)" }}>
+            {active.note || "No notes."}
+            <span className="mono" style={{ marginLeft: 12, fontSize: 10 }}>
+              {" · "}<button onClick={openRename} style={{ background: "none", border: "none", color: "inherit", cursor: "pointer", padding: 0, font: "inherit" }}>rename</button>
+              {" · "}<button onClick={del} style={{ background: "none", border: "none", color: scenarios.length <= 1 ? "var(--ink-4)" : "inherit", cursor: scenarios.length <= 1 ? "default" : "pointer", padding: 0, font: "inherit" }} disabled={scenarios.length <= 1}>delete</button>
+            </span>
+          </div>
+        </Panel>
+
+        <div className="grid g-2">
+          <Stat label={`Runway — ${active.name}`} value={runway} unit="months" size={60}
+            sub={`€${Math.round(netBurn).toLocaleString()}/mo net burn · ${active.partnerWorking ? "Maria working" : "no partner income"}`} />
+          <Stat label="Reserve pot" value={pot} size={38} showDec={false}
+            sub={["cash + receivables", active.includeInvest ? "+ brokerage" : null, active.includeBusiness ? "+ business" : null].filter(Boolean).join(" ")} />
+        </div>
+
+        <Panel title="Depletion curve" meta={`${runway} months until reserves reach zero`}>
+          <DepletionChart
+            width={1340}
+            months={Math.min(96, runway + 12)}
+            monthlyBurn={netBurn}
+            startValue={pot}
+            targetFloor={5000}
+          />
+        </Panel>
+
+        <div className="grid g-2">
+          {/* Scenario settings */}
+          <Panel title={`Settings — ${active.name}`} meta={`€${Math.round(scenBurn).toLocaleString()}/mo total spend`}>
+            <label className="flex-between" style={{ padding: "10px 0", cursor: "pointer" }}>
+              <span>Maria keeps working (€{Math.round(d.mIncome).toLocaleString()}/mo net)</span>
+              <input type="checkbox" checked={active.partnerWorking}
+                onChange={e => updActive("partnerWorking", e.target.checked)} />
+            </label>
+            <label className="flex-between" style={{ padding: "10px 0", borderTop: "1px solid var(--rule-soft)", cursor: "pointer" }}>
+              <span>Include brokerage (+€{Math.round(d.brokerageAssets).toLocaleString()})</span>
+              <input type="checkbox" checked={active.includeInvest}
+                onChange={e => updActive("includeInvest", e.target.checked)} />
+            </label>
+            <label className="flex-between" style={{ padding: "10px 0", borderTop: "1px solid var(--rule-soft)", cursor: "pointer" }}>
+              <span>Include business assets (+€{Math.round(d.businessAssets).toLocaleString()})</span>
+              <input type="checkbox" checked={active.includeBusiness}
+                onChange={e => updActive("includeBusiness", e.target.checked)} />
+            </label>
+            <hr className="rule" style={{ margin: "14px 0" }} />
+            <Smallcaps>Burn summary</Smallcaps>
+            <table className="table mt-sm">
+              <tbody>
+                <tr><td>Joint ({active.joint.length} items)</td><td className="num">€{Math.round(scenJoint).toLocaleString()}</td></tr>
+                <tr><td>Ashton personal ({active.ashtonP.length} items)</td><td className="num">€{Math.round(scenAshton).toLocaleString()}</td></tr>
+                <tr><td>Maria personal ({active.mariaP.length} items)</td><td className="num">€{Math.round(scenMaria).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>Gross burn</td><td className="num">€{Math.round(scenBurn).toLocaleString()}</td></tr>
+                {active.partnerWorking && <tr><td>− Maria income</td><td className="num pos">−€{Math.round(d.mIncome).toLocaleString()}</td></tr>}
+                <tr className="total"><td>Net burn</td><td className="num">€{Math.round(netBurn).toLocaleString()}</td></tr>
+              </tbody>
+            </table>
+          </Panel>
+
+          <Panel title="Milestones" meta="along the depletion curve">
+            <table className="table">
+              <tbody>
+                <tr><td>Month 6 balance</td><td className="num">€{Math.max(0, Math.round(pot - netBurn * 6)).toLocaleString()}</td></tr>
+                <tr><td>Month 12 balance</td><td className="num">€{Math.max(0, Math.round(pot - netBurn * 12)).toLocaleString()}</td></tr>
+                <tr><td>Month 24 balance</td><td className="num">€{Math.max(0, Math.round(pot - netBurn * 24)).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>Hit €5k floor</td><td className="num">month {Math.max(0, Math.floor((pot - 5000) / netBurn))}</td></tr>
+                <tr className="total"><td>Zero</td><td className="num">month {runway}</td></tr>
+              </tbody>
+            </table>
+          </Panel>
+        </div>
+
+        {/* Per-scenario expense editor */}
+        <Panel title={`Expenses — ${active.name}`} meta="edit independently of live inputs">
+          <div className="flex-between mb-md" style={{ alignItems: "center" }}>
+            <Segmented<ExpenseTab>
+              value={expTab}
+              onChange={setExpTab}
+              options={[
+                { value: "joint", label: `Joint (€${Math.round(scenJoint).toLocaleString()})` },
+                { value: "ashton", label: `Ashton (€${Math.round(scenAshton).toLocaleString()})` },
+                { value: "maria", label: `Maria (€${Math.round(scenMaria).toLocaleString()})` },
+              ]}
+            />
+            <span className="mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>
+              €{Math.round(currentTotal).toLocaleString()}/mo · €{Math.round(currentTotal * 12).toLocaleString()}/yr
+            </span>
+          </div>
+          <table className="table">
+            <thead>
+              <tr><th>Item</th><th className="num">Monthly</th><th className="num">Yearly</th><th></th></tr>
+            </thead>
+            <tbody>
+              {currentList.map((e, i) => (
+                <tr key={i}>
+                  <td>
+                    <input className="cell-input" value={e.label}
+                      onChange={ev => updExp(expTab, i, "label", ev.target.value)}
+                      style={{ minWidth: 200 }} />
+                  </td>
+                  <td className="num editable">
+                    <input className="cell-input mono" value={e.amt}
+                      onChange={ev => updExp(expTab, i, "amt", parseFloat(ev.target.value) || 0)}
+                      style={{ textAlign: "right", width: 80 }} />
+                  </td>
+                  <td className="num italic" style={{ color: "var(--ink-3)" }}>€{(e.amt * 12).toLocaleString()}</td>
+                  <td><button onClick={() => remExp(expTab, i)} style={{ color: "var(--ink-3)" }}>×</button></td>
+                </tr>
+              ))}
+              <tr className="total">
+                <td>Total</td>
+                <td className="num">€{Math.round(currentTotal).toLocaleString()}</td>
+                <td className="num">€{Math.round(currentTotal * 12).toLocaleString()}</td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+          <button className="btn mt-md" onClick={() => addExp(expTab)}>+ Add item</button>
+        </Panel>
+
+        {/* Side-by-side comparison */}
+        <Panel title="Compare scenarios" meta="side-by-side runway">
+          <table className="table">
+            <thead>
+              <tr><th>Scenario</th><th>Partner</th><th className="num">Gross burn</th><th className="num">Net burn</th><th className="num">Pot</th><th className="num">Runway</th><th style={{ width: 200 }}>Bar</th></tr>
+            </thead>
+            <tbody>
+              {scenarios.map(s => {
+                const sBurn = s.joint.reduce((a, e) => a + e.amt, 0)
+                  + s.ashtonP.reduce((a, e) => a + e.amt, 0)
+                  + s.mariaP.reduce((a, e) => a + e.amt, 0);
+                const sNetBurn = Math.max(100, sBurn - (s.partnerWorking ? d.mIncome : 0));
+                let sPot = d.liquidAssets;
+                if (s.includeInvest) sPot += d.brokerageAssets;
+                if (s.includeBusiness) sPot += d.businessAssets;
+                const sRunway = Math.floor(sPot / sNetBurn);
+                const maxRunway = 120;
+                return (
+                  <tr key={s.id} onClick={() => setActiveId(s.id)}
+                    style={{ cursor: "pointer", background: s.id === activeId ? "var(--paper-2)" : "transparent" }}>
+                    <td>{s.name}</td>
+                    <td>{s.partnerWorking ? "working" : "—"}</td>
+                    <td className="num">€{Math.round(sBurn).toLocaleString()}</td>
+                    <td className="num">€{Math.round(sNetBurn).toLocaleString()}</td>
+                    <td className="num">€{Math.round(sPot).toLocaleString()}</td>
+                    <td className="num" style={{ fontWeight: 600 }}>{sRunway} mo</td>
+                    <td><Bar pct={Math.min(100, sRunway / maxRunway * 100)} variant="ink" height={10} /></td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </Panel>
+      </div>
+
+      {modal !== null && (
+        <LedgerModal
+          title={modal === "new" ? "New scenario — copy of live inputs" : `Rename "${active.name}"`}
+          onClose={() => setModal(null)}
+        >
+          <div style={{ padding: 20, display: "flex", flexDirection: "column", gap: 16, minWidth: 360 }}>
+            <div>
+              <div className="smallcaps mb-sm">{modal === "new" ? "Scenario name" : "New name"}</div>
+              <input
+                autoFocus
+                className="cell-input"
+                value={modalInput}
+                onChange={e => setModalInput(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter") confirmModal(); if (e.key === "Escape") setModal(null); }}
+                style={{ width: "100%", padding: "8px 10px", border: "1px solid var(--rule)", background: "var(--paper)", fontFamily: "var(--serif)", fontSize: 15 }}
+                placeholder={modal === "new" ? "e.g. Lean + sabbatical" : active.name}
+              />
+              {modal === "new" && (
+                <div className="italic mt-sm" style={{ fontSize: 12, color: "var(--ink-3)" }}>
+                  Starts as a copy of your current live spending. Edit expenses in the scenario independently.
+                </div>
+              )}
+            </div>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button className="btn ghost" onClick={() => setModal(null)}>Cancel</button>
+              <button className="btn primary" onClick={confirmModal}>{modal === "new" ? "Create" : "Rename"}</button>
+            </div>
+          </div>
+        </LedgerModal>
+      )}
+    </>
+  );
+}

--- a/app/pages/ledger/state.ts
+++ b/app/pages/ledger/state.ts
@@ -1,0 +1,75 @@
+import type { Dispatch, SetStateAction } from "react";
+import type {
+  Asset, BizCost, Debt, Expense, Income, Iou, PensionAccount, Scenario, SplitMode, TaxRates
+} from "./data.js";
+
+export interface LedgerState {
+  income: Income;
+  setIncome: Dispatch<SetStateAction<Income>>;
+  joint: Expense[];
+  setJoint: Dispatch<SetStateAction<Expense[]>>;
+  ashtonP: Expense[];
+  setAshtonP: Dispatch<SetStateAction<Expense[]>>;
+  mariaP: Expense[];
+  setMariaP: Dispatch<SetStateAction<Expense[]>>;
+  assets: Asset[];
+  setAssets: Dispatch<SetStateAction<Asset[]>>;
+  debts: Debt[];
+  setDebts: Dispatch<SetStateAction<Debt[]>>;
+  ious: Iou[];
+  setIous: Dispatch<SetStateAction<Iou[]>>;
+  bizCosts: BizCost[];
+  setBizCosts: Dispatch<SetStateAction<BizCost[]>>;
+  bizRevenue: number;
+  setBizRevenue: Dispatch<SetStateAction<number>>;
+  splitMode: SplitMode;
+  setSplitMode: Dispatch<SetStateAction<SplitMode>>;
+  tax: TaxRates;
+  setTax: Dispatch<SetStateAction<TaxRates>>;
+  scenarios: Scenario[];
+  setScenarios: Dispatch<SetStateAction<Scenario[]>>;
+  dashView: "joint" | "ashton" | "partner";
+  setDashView: Dispatch<SetStateAction<"joint" | "ashton" | "partner">>;
+  amtPeriod: "monthly" | "annual";
+  setAmtPeriod: Dispatch<SetStateAction<"monthly" | "annual">>;
+  pensions: PensionAccount[];
+  setPensions: Dispatch<SetStateAction<PensionAccount[]>>;
+}
+
+export interface Derived {
+  jointTotal: number;
+  aPersonal: number;
+  mPersonal: number;
+  aIncome: number;
+  mIncome: number;
+  aGross: number;
+  mGross: number;
+  aShare: number;
+  mShare: number;
+  aBurn: number;
+  mBurn: number;
+  hhBurn: number;
+  hhIncome: number;
+  hhSaving: number;
+  personalAssets: number;
+  personalAssetsA: number;
+  personalAssetsM: number;
+  businessAssets: number;
+  liquidAssets: number;
+  liquidA: number;
+  liquidM: number;
+  brokerageAssets: number;
+  pensionAssets: number;
+  totalAssets: number;
+  totalDebt: number;
+  debtA: number;
+  debtM: number;
+  netWorth: number;
+  netWorthA: number;
+  netWorthM: number;
+  bizCostTotal: number;
+  bizNet: number;
+  iouIncoming: number;
+  iouOutgoing: number;
+  iouNet: number;
+}

--- a/app/pages/ledger/styles.css
+++ b/app/pages/ledger/styles.css
@@ -1,0 +1,682 @@
+/* ------------------------------------------------------------------
+   The Ledger — warm editorial
+   Paper + ink + rust. Dense power-user grid. Tabular numerals.
+------------------------------------------------------------------- */
+
+/* Escape from the site's max-w-3xl Content wrapper and position below the sticky nav.
+   Nav height: ~57px on mobile (py-2.5 + h-9 + border), ~61px on sm+ (py-3 + h-9 + border).
+   z-index: 50 — the site nav is z-index: 110 so it stays on top. */
+.ledger-layout-escape {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  padding-top: 57px;
+}
+@media (min-width: 640px) {
+  .ledger-layout-escape { padding-top: 61px; }
+}
+
+.ledger-root {
+  --paper: #F2ECDF;
+  --paper-2: #ECE4D2;
+  --paper-3: #E4DAC2;
+  --ink: #1B1714;
+  --ink-2: #3A342C;
+  --ink-3: #6B6358;
+  --ink-4: #9A907F;
+  --rule: #1B1714;
+  --rule-soft: rgba(27,23,20,0.18);
+  --rule-hair: rgba(27,23,20,0.10);
+  --rust: oklch(55% 0.14 40);
+  --rust-soft: oklch(55% 0.14 40 / 0.12);
+  --moss: oklch(48% 0.07 145);
+  --moss-soft: oklch(48% 0.07 145 / 0.14);
+  --indigo: oklch(42% 0.10 265);
+  --indigo-soft: oklch(42% 0.10 265 / 0.14);
+  --ochre: oklch(68% 0.13 75);
+  --crimson: oklch(48% 0.16 25);
+
+  --serif: "Old Standard TT", "Times New Roman", serif;
+  --italic: "Instrument Serif", "Times New Roman", serif;
+  --mono: "JetBrains Mono", ui-monospace, monospace;
+
+  --tnum: "tnum" 1, "lnum" 1;
+
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-feature-settings: var(--tnum);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: geometricPrecision;
+  /* flex child of .ledger-layout-escape */
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background-image:
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(27,23,20,0.012) 2px 3px);
+}
+
+.ledger-root * { box-sizing: border-box; }
+
+.ledger-root button { font: inherit; color: inherit; background: none; border: 0; padding: 0; cursor: pointer; }
+.ledger-root input, .ledger-root select, .ledger-root textarea { font: inherit; color: inherit; }
+.ledger-root input:focus, .ledger-root select:focus, .ledger-root textarea:focus { outline: 1px solid var(--ink); outline-offset: 2px; }
+
+/* ------------------------------------------------------------- layout */
+
+.ledger-root .app {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  height: 100%;
+}
+
+.ledger-root .sidebar {
+  border-right: 1px solid var(--rule);
+  padding: 22px 20px 28px;
+  height: 100%;
+  overflow-y: auto;
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.ledger-root .masthead {
+  border-bottom: 3px double var(--ink);
+  padding-bottom: 14px;
+}
+.ledger-root .masthead .crest {
+  font-family: var(--italic);
+  font-style: italic;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  color: var(--ink-3);
+}
+.ledger-root .masthead h1 {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 26px;
+  line-height: 1.0;
+  margin: 2px 0 4px;
+  letter-spacing: -0.01em;
+}
+.ledger-root .masthead .edition {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  display: flex;
+  justify-content: space-between;
+}
+
+.ledger-root .nav-section-label {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0 0 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--rule-soft);
+}
+.ledger-root .nav ul { list-style: none; margin: 0; padding: 0; }
+.ledger-root .nav li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 5px 0;
+  border-bottom: 1px dotted var(--rule-hair);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.ledger-root .nav li:hover { background: var(--paper-2); }
+.ledger-root .nav li.active { font-weight: 700; }
+.ledger-root .nav li.active .nav-label::before {
+  content: "▸ ";
+  color: var(--rust);
+}
+.ledger-root .nav-label { font-size: 15px; }
+.ledger-root .nav-num {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-4);
+  letter-spacing: 0.05em;
+}
+
+.ledger-root .sidebar .footer-note {
+  margin-top: auto;
+  font-family: var(--italic);
+  font-style: italic;
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--ink-3);
+  padding-top: 14px;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.ledger-root .main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100%;
+  overflow-y: auto;
+}
+
+/* ------------------------------------------------------------- folio */
+.ledger-root .folio {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: end;
+  padding: 18px 32px 14px;
+  border-bottom: 3px double var(--ink);
+  gap: 24px;
+}
+.ledger-root .folio .left, .ledger-root .folio .right {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  display: flex;
+  gap: 18px;
+}
+.ledger-root .folio .right { justify-content: flex-end; }
+.ledger-root .folio .center { text-align: center; }
+.ledger-root .folio .kicker {
+  font-family: var(--italic);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--rust);
+  margin-bottom: 2px;
+}
+.ledger-root .folio h2 {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 40px;
+  line-height: 1;
+  margin: 0;
+  letter-spacing: -0.015em;
+}
+.ledger-root .folio .dek {
+  font-family: var(--italic);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--ink-2);
+  margin-top: 6px;
+  max-width: 560px;
+  margin-left: auto;
+  margin-right: auto;
+  text-wrap: balance;
+}
+
+.ledger-root .content {
+  padding: 20px 32px 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* ------------------------------------------------------------- typography */
+.ledger-root .mono { font-family: var(--mono); font-feature-settings: var(--tnum); }
+.ledger-root .italic { font-family: var(--italic); font-style: italic; }
+.ledger-root .smallcaps {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.ledger-root .rule { border: 0; border-top: 1px solid var(--rule); margin: 0; }
+.ledger-root .rule-double { border: 0; border-top: 3px double var(--ink); margin: 0; }
+
+.ledger-root .figure {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-feature-settings: var(--tnum);
+  letter-spacing: -0.015em;
+  line-height: 0.95;
+}
+.ledger-root .figure .cur {
+  font-family: var(--italic);
+  font-style: italic;
+  font-weight: 400;
+  color: var(--ink-3);
+  margin-right: 3px;
+  font-size: 0.55em;
+  vertical-align: 0.25em;
+}
+.ledger-root .figure .decimal { color: var(--ink-3); font-size: 0.62em; }
+
+.ledger-root .pos { color: var(--moss); }
+.ledger-root .neg { color: var(--crimson); }
+
+/* ------------------------------------------------------------- panels */
+.ledger-root .panel {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  position: relative;
+}
+.ledger-root .panel.ruled { border: 1px solid var(--rule); }
+.ledger-root .panel.hairline { border: 1px solid var(--rule-soft); background: transparent; }
+.ledger-root .panel.cream { background: var(--paper-2); border: 1px solid var(--rule-soft); }
+
+.ledger-root .panel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--rule);
+  gap: 12px;
+}
+.ledger-root .panel-head .title {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.005em;
+}
+.ledger-root .panel-head .meta {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.ledger-root .panel-body { padding: 14px; }
+.ledger-root .panel-body.tight { padding: 10px 14px; }
+.ledger-root .panel-body.flush { padding: 0; }
+
+.ledger-root .stat { padding: 14px 16px 16px; }
+.ledger-root .stat .label {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 8px;
+  display: flex;
+  justify-content: space-between;
+}
+.ledger-root .stat .value {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 42px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  font-feature-settings: var(--tnum);
+}
+.ledger-root .stat .sub {
+  margin-top: 8px;
+  font-family: var(--italic);
+  font-style: italic;
+  font-size: 12.5px;
+  color: var(--ink-3);
+}
+.ledger-root .stat .delta {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+
+/* ------------------------------------------------------------- tables */
+.ledger-root .table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.ledger-root .table th {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--rule);
+  font-weight: 400;
+}
+.ledger-root .table td {
+  padding: 7px 10px;
+  border-bottom: 1px dotted var(--rule-hair);
+  vertical-align: baseline;
+}
+.ledger-root .table tr:last-child td { border-bottom: 0; }
+.ledger-root .table tr:hover td { background: var(--paper-2); }
+.ledger-root .table td.num, .ledger-root .table th.num {
+  text-align: right;
+  font-family: var(--mono);
+  font-feature-settings: var(--tnum);
+}
+.ledger-root .table tr.total td {
+  border-top: 1px solid var(--rule);
+  border-bottom: 3px double var(--ink);
+  font-weight: 700;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.ledger-root .table tr.subtotal td {
+  border-top: 1px solid var(--rule-soft);
+  font-style: italic;
+  font-family: var(--italic);
+  color: var(--ink-2);
+}
+.ledger-root .table td .pill {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  padding: 1px 6px;
+  border: 1px solid var(--rule-soft);
+  text-transform: uppercase;
+}
+.ledger-root .table td.editable { position: relative; cursor: text; }
+.ledger-root .table td.editable:hover {
+  background: var(--paper-3);
+  outline: 1px dashed var(--ink-3);
+  outline-offset: -1px;
+}
+.ledger-root .table input.cell-input {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font: inherit;
+  text-align: inherit;
+  color: inherit;
+  padding: 0;
+}
+
+/* ------------------------------------------------------------- tabs / segmented */
+.ledger-root .segmented {
+  display: inline-flex;
+  border: 1px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+}
+.ledger-root .segmented button {
+  padding: 5px 10px;
+  border-right: 1px solid var(--rule);
+  color: var(--ink-3);
+}
+.ledger-root .segmented button:last-child { border-right: 0; }
+.ledger-root .segmented button.on { background: var(--ink); color: var(--paper); }
+
+/* ------------------------------------------------------------- chips */
+.ledger-root .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border: 1px solid var(--rule-soft);
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--ink-2);
+}
+.ledger-root .chip.rust { color: var(--rust); border-color: var(--rust); }
+.ledger-root .chip.moss { color: var(--moss); border-color: var(--moss); }
+.ledger-root .chip.indigo { color: var(--indigo); border-color: var(--indigo); }
+
+/* ------------------------------------------------------------- buttons */
+.ledger-root .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border: 1px solid var(--ink);
+  background: var(--paper);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.1s;
+}
+.ledger-root .btn:hover { background: var(--ink); color: var(--paper); }
+.ledger-root .btn.primary { background: var(--ink); color: var(--paper); }
+.ledger-root .btn.primary:hover { background: var(--rust); border-color: var(--rust); }
+.ledger-root .btn.ghost { border-color: var(--rule-soft); color: var(--ink-2); }
+
+/* ------------------------------------------------------------- grids */
+.ledger-root .grid { display: grid; gap: 14px; }
+.ledger-root .g-4 { grid-template-columns: repeat(4, 1fr); }
+.ledger-root .g-3 { grid-template-columns: repeat(3, 1fr); }
+.ledger-root .g-2 { grid-template-columns: repeat(2, 1fr); }
+.ledger-root .g-2-1 { grid-template-columns: 2fr 1fr; }
+.ledger-root .g-1-2 { grid-template-columns: 1fr 2fr; }
+.ledger-root .g-3-2 { grid-template-columns: 3fr 2fr; }
+
+/* ------------------------------------------------------------- bars */
+.ledger-root .bar { height: 6px; background: var(--paper-3); position: relative; overflow: hidden; }
+.ledger-root .bar .fill { position: absolute; inset: 0 auto 0 0; background: var(--ink); }
+.ledger-root .bar.rust .fill { background: var(--rust); }
+.ledger-root .bar.moss .fill { background: var(--moss); }
+.ledger-root .bar.indigo .fill { background: var(--indigo); }
+.ledger-root .bar.stacked { display: flex; }
+.ledger-root .bar.stacked .fill { position: relative; inset: auto; }
+
+.ledger-root .bar-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: baseline;
+  margin-bottom: 4px;
+  font-size: 13px;
+}
+.ledger-root .bar-row .num { font-family: var(--mono); font-size: 11px; color: var(--ink-2); }
+
+/* ------------------------------------------------------------- charts */
+.ledger-root svg.chart { display: block; width: 100%; overflow: visible; }
+.ledger-root svg.chart text {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  fill: var(--ink-3);
+  letter-spacing: 0.06em;
+}
+.ledger-root svg.chart .axis { stroke: var(--rule); stroke-width: 1; }
+.ledger-root svg.chart .grid-line { stroke: var(--rule-hair); stroke-width: 1; stroke-dasharray: 2 3; }
+.ledger-root svg.chart .area { fill: var(--rust-soft); }
+.ledger-root svg.chart .line { stroke: var(--ink); stroke-width: 1.5; fill: none; }
+.ledger-root svg.chart .line-soft { stroke: var(--ink-3); stroke-width: 1; fill: none; stroke-dasharray: 2 3; }
+.ledger-root svg.chart .marker { fill: var(--rust); }
+
+/* ------------------------------------------------------------- avatars */
+.ledger-root .who {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.ledger-root .who .dot {
+  width: 8px;
+  height: 8px;
+  display: inline-block;
+  border: 1px solid var(--ink);
+}
+.ledger-root .who.ashton .dot { background: var(--ink); }
+.ledger-root .who.e .dot { background: var(--paper); }
+
+/* utility */
+.ledger-root .flex { display: flex; }
+.ledger-root .flex-between { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
+.ledger-root .flex-col { display: flex; flex-direction: column; }
+.ledger-root .gap-xs { gap: 6px; }
+.ledger-root .gap-sm { gap: 10px; }
+.ledger-root .gap-md { gap: 14px; }
+.ledger-root .gap-lg { gap: 20px; }
+.ledger-root .ml-auto { margin-left: auto; }
+.ledger-root .text-right { text-align: right; }
+.ledger-root .text-center { text-align: center; }
+.ledger-root .w-full { width: 100%; }
+.ledger-root .mb-sm { margin-bottom: 8px; }
+.ledger-root .mb-md { margin-bottom: 14px; }
+.ledger-root .mb-lg { margin-bottom: 20px; }
+.ledger-root .mt-sm { margin-top: 8px; }
+.ledger-root .mt-md { margin-top: 14px; }
+
+/* ------------------------------------------------------------- mobile nav */
+.ledger-root .mobile-header {
+  display: none;
+  flex-direction: column;
+  border-bottom: 2px solid var(--rule);
+  background: var(--paper);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.ledger-root .mobile-header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px 8px;
+  border-bottom: 1px solid var(--rule-soft);
+}
+.ledger-root .mobile-header-bar .mobile-title {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.ledger-root .mobile-header-bar .mobile-edition {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.ledger-root .mobile-tabs {
+  display: flex;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.ledger-root .mobile-tabs::-webkit-scrollbar { display: none; }
+.ledger-root .mobile-tabs button {
+  flex: 1;
+  min-width: max-content;
+  padding: 9px 14px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  border-right: 1px solid var(--rule-soft);
+  white-space: nowrap;
+}
+.ledger-root .mobile-tabs button:last-child { border-right: 0; }
+.ledger-root .mobile-tabs button.active {
+  color: var(--ink);
+  font-weight: 700;
+  border-bottom: 2px solid var(--rust);
+}
+
+/* ------------------------------------------------------------- responsive */
+
+/* Tablet + Mobile: hide sidebar, show mobile header */
+@media (max-width: 1023px) {
+  .ledger-root .app {
+    grid-template-columns: 1fr;
+  }
+  .ledger-root .sidebar {
+    display: none;
+  }
+  .ledger-root .mobile-header {
+    display: flex;
+  }
+}
+
+/* Tablet: slightly compress content padding */
+@media (max-width: 1023px) {
+  .ledger-root .content {
+    padding: 16px 20px 48px;
+    gap: 14px;
+  }
+  .ledger-root .folio {
+    padding: 14px 20px 12px;
+  }
+  .ledger-root .g-3 { grid-template-columns: repeat(2, 1fr); }
+  .ledger-root .g-4 { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* Mobile: single column everything */
+@media (max-width: 639px) {
+  .ledger-root .content {
+    padding: 12px 14px 40px;
+    gap: 12px;
+  }
+  .ledger-root .folio {
+    grid-template-columns: 1fr;
+    padding: 12px 14px 10px;
+    gap: 4px;
+  }
+  .ledger-root .folio .left,
+  .ledger-root .folio .right { display: none; }
+  .ledger-root .folio h2 { font-size: 26px; }
+  .ledger-root .folio .dek { font-size: 12.5px; margin-top: 4px; }
+
+  .ledger-root .g-2 { grid-template-columns: 1fr; }
+  .ledger-root .g-2-1 { grid-template-columns: 1fr; }
+  .ledger-root .g-1-2 { grid-template-columns: 1fr; }
+  .ledger-root .g-3 { grid-template-columns: 1fr; }
+  .ledger-root .g-3-2 { grid-template-columns: 1fr; }
+  .ledger-root .g-4 { grid-template-columns: repeat(2, 1fr); }
+
+  .ledger-root .stat { padding: 12px 14px 14px; }
+  .ledger-root .stat .value { font-size: 32px; }
+
+  .ledger-root .panel-head { padding: 8px 12px; }
+  .ledger-root .panel-body { padding: 12px; }
+}
+
+/* ------------------------------------------------------------- scrollbar */
+.ledger-root ::-webkit-scrollbar { width: 6px; height: 6px; }
+.ledger-root ::-webkit-scrollbar-track { background: var(--paper-2); }
+.ledger-root ::-webkit-scrollbar-thumb { background: var(--ink-3); }
+.ledger-root ::-webkit-scrollbar-thumb:hover { background: var(--ink); }
+.ledger-root { scrollbar-width: thin; scrollbar-color: var(--ink-3) var(--paper-2); }
+
+/* ------------------------------------------------------------- modal */
+.ledger-modal-backdrop {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(27,23,20,0.65);
+  display: flex; align-items: center; justify-content: center;
+}
+.ledger-modal {
+  background: var(--paper);
+  border: 2px solid var(--rule);
+  display: flex; flex-direction: column;
+  max-width: 90vw; max-height: 90vh;
+  overflow: hidden;
+}
+.ledger-modal.wide { width: 98vw; height: 96vh; max-width: 98vw; max-height: 96vh; }
+.ledger-modal-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 10px 14px 8px; border-bottom: 1px solid var(--rule); gap: 12px; flex-shrink: 0;
+}
+.ledger-modal-head .title { font-family: var(--serif); font-weight: 700; font-size: 15px; }
+.ledger-modal-head .meta { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); }
+.ledger-modal-close { font-size: 20px; line-height: 1; padding: 0 2px; color: var(--ink-3); cursor: pointer; margin-left: auto; }
+.ledger-modal-close:hover { color: var(--ink); }
+.ledger-modal-body { flex: 1; overflow: auto; }
+
+/* ------------------------------------------------------------- nav override (ledger page) */
+body.ledger-active [class~="sticky"] {
+  background: #F2ECDF !important;
+  border-color: #1B1714 !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+body.ledger-active [class~="sticky"] nav a,
+body.ledger-active [class~="sticky"] nav li {
+  color: #1B1714 !important;
+}
+body.ledger-active [class~="sticky"] nav a:hover {
+  background: rgba(27,23,20,0.08) !important;
+}
+/* Theme toggle button */
+body.ledger-active [class~="sticky"] button {
+  color: #1B1714 !important;
+}

--- a/app/pages/ledger/useLedgerSync.ts
+++ b/app/pages/ledger/useLedgerSync.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { apiClient } from "../../ts-rest/api-client.js";
+import type { LedgerStatePayload } from "../../ts-rest/contract.js";
+
+export type SyncStatus = "loading" | "idle" | "saving" | "saved" | "error";
+
+export function useLedgerSync(
+  payload: LedgerStatePayload,
+  onLoad: (state: LedgerStatePayload) => void,
+  userId = "ashton",
+) {
+  const [status, setStatus] = useState<SyncStatus>("loading");
+  const [lastSaved, setLastSaved] = useState<string | null>(null);
+  // Stays true until the initial load resolves — suppresses the save-on-change effect
+  const initialising = useRef(true);
+  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const persist = useCallback(async (data: LedgerStatePayload) => {
+    setStatus("saving");
+    try {
+      const res = await apiClient.saveLedgerState({ query: { userId }, body: data });
+      if (res.status === 200) {
+        setLastSaved(res.body.updatedAt);
+        setStatus("saved");
+        setTimeout(() => setStatus("idle"), 2500);
+      } else {
+        setStatus("error");
+      }
+    } catch {
+      setStatus("error");
+    }
+  }, [userId]);
+
+  // Load on mount; if DB is empty, seed with the caller's current defaults
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await apiClient.getLedgerState({ query: { userId } });
+        if (cancelled) return;
+        if (res.status === 200) {
+          if (res.body.state !== null) {
+            onLoad(res.body.state);
+            setLastSaved(res.body.updatedAt);
+            setStatus("idle");
+          } else {
+            // First run — seed DB with default data.ts values
+            await persist(payload);
+          }
+        } else {
+          setStatus("error");
+        }
+      } catch {
+        // API not reachable (local dev without AWS) — just continue with defaults
+        setStatus("idle");
+      } finally {
+        if (!cancelled) initialising.current = false;
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Debounced auto-save whenever the payload changes after initial load
+  useEffect(() => {
+    if (initialising.current) return;
+    clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => persist(payload), 2000);
+    return () => clearTimeout(saveTimer.current);
+  }, [payload, persist]);
+
+  return { status, lastSaved };
+}

--- a/app/server/ts-rest-handler.ts
+++ b/app/server/ts-rest-handler.ts
@@ -2,6 +2,11 @@ import { fetchRequestHandler, tsr } from "@ts-rest/serverless/fetch";
 import { contract } from "../ts-rest/contract";
 // TODO: stop using universal-middleware and directly integrate server middlewares instead and/or use vike-server https://vike.dev/server. (Bati generates boilerplates that use universal-middleware https://github.com/magne4000/universal-middleware to make Bati's internal logic easier. This is temporary and will be removed soon.)
 import { Get, UniversalHandler } from "@universal-middleware/core";
+import { DynamoDBClient, GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+
+const dynamo = new DynamoDBClient({});
+const TABLE = process.env.LEDGER_TABLE_NAME ?? "";
 
 /**
  * ts-rest route
@@ -25,6 +30,37 @@ const router = tsr.platformContext<object>().router(contract, {
         status: "Ok",
       },
     };
+  },
+
+  getLedgerState: async ({ query }) => {
+    if (!TABLE) return { status: 500, body: { error: "LEDGER_TABLE_NAME not configured" } };
+    try {
+      const result = await dynamo.send(new GetItemCommand({
+        TableName: TABLE,
+        Key: marshall({ userId: query.userId, dataKey: "ledger#state" }),
+      }));
+      if (!result.Item) return { status: 200, body: { state: null, updatedAt: null } };
+      const item = unmarshall(result.Item);
+      return { status: 200, body: { state: item.state as never, updatedAt: item.updatedAt as string } };
+    } catch (e) {
+      console.error("getLedgerState error", e);
+      return { status: 500, body: { error: "Failed to read ledger state" } };
+    }
+  },
+
+  saveLedgerState: async ({ body, query }) => {
+    if (!TABLE) return { status: 500, body: { error: "LEDGER_TABLE_NAME not configured" } };
+    try {
+      const updatedAt = new Date().toISOString();
+      await dynamo.send(new PutItemCommand({
+        TableName: TABLE,
+        Item: marshall({ userId: query.userId, dataKey: "ledger#state", state: body, updatedAt }, { removeUndefinedValues: true }),
+      }));
+      return { status: 200, body: { ok: true, updatedAt } };
+    } catch (e) {
+      console.error("saveLedgerState error", e);
+      return { status: 500, body: { error: "Failed to save ledger state" } };
+    }
   },
 });
 

--- a/app/ts-rest/api-client.ts
+++ b/app/ts-rest/api-client.ts
@@ -1,0 +1,8 @@
+import { initClient } from "@ts-rest/core";
+import { contract } from "./contract.js";
+
+// Browser-side ts-rest client — relative baseUrl works for same-origin API
+export const apiClient = initClient(contract, {
+  baseUrl: "",
+  baseHeaders: {},
+});

--- a/app/ts-rest/contract.ts
+++ b/app/ts-rest/contract.ts
@@ -1,6 +1,26 @@
 import { initContract } from "@ts-rest/core";
+import { z } from "zod";
 
 const c = initContract();
+
+// Ledger state blob — stored as opaque JSON, validated by presence of key fields
+const LedgerStateSchema = z.object({
+  income: z.record(z.unknown()),
+  joint: z.array(z.unknown()),
+  ashtonP: z.array(z.unknown()),
+  mariaP: z.array(z.unknown()),
+  assets: z.array(z.unknown()),
+  debts: z.array(z.unknown()),
+  ious: z.array(z.unknown()),
+  bizCosts: z.array(z.unknown()),
+  bizRevenue: z.number(),
+  splitMode: z.string(),
+  tax: z.record(z.number()),
+  scenarios: z.array(z.unknown()),
+  pensions: z.array(z.unknown()).optional(),
+}).passthrough();
+
+export type LedgerStatePayload = z.infer<typeof LedgerStateSchema>;
 
 /**
  * ts-rest contract
@@ -26,6 +46,30 @@ export const contract = c.router(
         200: c.type<{ status: string }>(),
       },
       summary: "Create a Todo",
+    },
+
+    // Ledger API — save/load the full ledger state for a user
+    getLedgerState: {
+      method: "GET",
+      path: "/ledger/state",
+      query: z.object({ userId: z.string().default("ashton") }),
+      responses: {
+        200: c.type<{ state: LedgerStatePayload | null; updatedAt: string | null }>(),
+        500: c.type<{ error: string }>(),
+      },
+      summary: "Get saved ledger state",
+    },
+    saveLedgerState: {
+      method: "PUT",
+      path: "/ledger/state",
+      query: z.object({ userId: z.string().default("ashton") }),
+      body: LedgerStateSchema,
+      responses: {
+        200: c.type<{ ok: boolean; updatedAt: string }>(),
+        400: c.type<{ error: string }>(),
+        500: c.type<{ error: string }>(),
+      },
+      summary: "Save ledger state",
     },
   },
   {


### PR DESCRIPTION
Adds a full-screen financial dashboard at /ledger with five screens: Dashboard, Money Flow (Sankey), Runway, Retirement, and Inputs. State is persisted to DynamoDB via a new ts-rest API with auto-save (2s debounce) and seeds the database from hardcoded defaults on first load.

Infrastructure (CDK):
- DynamoDB table (PK: userId, SK: dataKey) with PITR, RETAIN policy
- Lambda granted read/write access; LEDGER_TABLE_NAME env var injected
- SSM parameter storing table name
- @aws-sdk/client-dynamodb + @aws-sdk/util-dynamodb added to dependencies
- Vite SSR config: AWS SDK marked external so worktree dev resolves correctly

API (ts-rest):
- GET /api/ledger/state?userId= — load saved blob
- PUT /api/ledger/state?userId= — save full state blob (Zod-validated)
- Browser client in app/ts-rest/api-client.ts

Dashboard features:
- Joint / Ashton / Maria selector driving headline runway, assets donut, saving rate, and net worth stats
- "This month" table with business revenue → costs → retained breakdown
- Category spending comparison with hover tooltip showing per-expense detail
- Net worth 12-month area chart (bottom)

Sankey (Money Flow):
- Dynamic SVG height — top and bottom streams sized from content, eliminating node overlap regardless of revenue/cost ratios
- Drag-to-reorder nodes within any column; ribbons re-route live
- Hover highlights only the hovered ribbon (others unchanged)
- Fullscreen modal + category breakdown toggle

Runway:
- Per-scenario expense snapshots (each scenario starts as a copy of current inputs, editable independently)
- Joint runway pot includes liquid + brokerage + business assets

Retirement screen:
- FI number, projected portfolio, pension accounts, assumption sliders

Other:
- Monthly / annual toggle
- Styled scrollbar, modal portal, responsive layout (fixed + flex escape from parent max-w-3xl container)
- Sync status badge in sidebar (loading / saving / saved / error)