### PR TITLE
Ledger: bug fixes, UX improvements, and mobile responsiveness

### DIFF
--- a/app/pages/ledger/+Page.tsx
+++ b/app/pages/ledger/+Page.tsx
@@ -35,7 +35,7 @@ const ROUTES: RouteDef[] = [
 
 import type { SyncStatus } from "./useLedgerSync.js";
 
-function SyncBadge({ status, lastSaved }: { status: SyncStatus; lastSaved: string | null }) {
+function SyncBadge({ status, lastSaved, onRefresh }: { status: SyncStatus; lastSaved: string | null; onRefresh: () => void }) {
   const dot: Record<SyncStatus, { label: string; color: string }> = {
     loading: { label: "loading…",  color: "var(--ink-3)" },
     idle:    { label: lastSaved ? `saved ${new Date(lastSaved).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}` : "local only", color: "var(--ink-4)" },
@@ -45,9 +45,16 @@ function SyncBadge({ status, lastSaved }: { status: SyncStatus; lastSaved: strin
   };
   const { label, color } = dot[status];
   return (
-    <div style={{ marginTop: 10, display: "flex", alignItems: "center", gap: 5, fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.1em", color }}>
+    <div style={{ marginTop: 10, display: "flex", alignItems: "center", gap: 8, fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.1em", color }}>
       <span style={{ width: 5, height: 5, borderRadius: "50%", background: color, display: "inline-block", flexShrink: 0 }} />
-      {label.toUpperCase()}
+      <span>{label.toUpperCase()}</span>
+      <button
+        onClick={onRefresh}
+        title="Pull latest from the server (useful if you edited on another device)"
+        style={{ marginLeft: "auto", fontFamily: "var(--mono)", fontSize: 9, letterSpacing: "0.1em", color: "var(--ink-3)", textDecoration: "underline", cursor: "pointer" }}
+      >
+        REFRESH
+      </button>
     </div>
   );
 }
@@ -111,7 +118,7 @@ export default function LedgerPage() {
     if (s.pensions) setPensions(s.pensions as PensionAccount[]);
   }, []);
 
-  const { status: syncStatus, lastSaved } = useLedgerSync(syncPayload, onLoad);
+  const { status: syncStatus, lastSaved, reload } = useLedgerSync(syncPayload, onLoad);
 
   const state: LedgerState = {
     income, setIncome,
@@ -137,9 +144,12 @@ export default function LedgerPage() {
     const mPersonal = mariaP.reduce((s, x) => s + x.amt, 0);
     const aDividendNet = income.ashton.dividend * (1 - tax.dividendTaxRate);
     const aIncome = income.ashton.salary + aDividendNet;
-    const mGrossSalary = income.partner.gross || income.partner.total;
-    const mIncome = mGrossSalary * (1 - tax.mariaTaxRate);
-    const aGross = income.ashton.gross || aIncome;
+    // partner.salary is the source of truth for Maria's net take-home — editable in both
+    // net and gross modes in the Income section. Gross is derived from it + tax rate so
+    // Dashboard and Flow always reflect the latest salary edit.
+    const mIncome = income.partner.salary || 0;
+    const mGrossSalary = tax.mariaTaxRate < 1 ? mIncome / (1 - tax.mariaTaxRate) : mIncome;
+    const aGross = tax.salaryTaxRate < 1 ? (income.ashton.salary / (1 - tax.salaryTaxRate)) + income.ashton.dividend : aIncome;
     const mGross = mGrossSalary;
     const bizNetLocal = bizRevenue - bizCosts.reduce((s, c) => s + c.amt, 0);
     let aShare: number;
@@ -168,15 +178,24 @@ export default function LedgerPage() {
     const brokerageAssets = assets.filter(a => a.type === "brokerage").reduce((s, a) => s + a.bal * fx[a.cur], 0);
     const pensionAssets = assets.filter(a => a.type === "pension").reduce((s, a) => s + a.bal * fx[a.cur], 0);
     const totalAssets = personalAssets + businessAssets;
-    const debtA = debts.filter(dd => dd.owner === "ashton").reduce((s, dd) => s + dd.bal * fx[dd.cur], 0);
-    const debtM = debts.filter(dd => dd.owner === "partner").reduce((s, dd) => s + dd.bal * fx[dd.cur], 0);
-    const totalDebt = debts.reduce((s, dd) => s + dd.bal * fx[dd.cur], 0);
+    // Debts can be owed to an outside party ("external") or to the other partner.
+    // Internal debts cancel at the household level but still shift each person's net worth.
+    const eurBal = (dd: Debt) => dd.bal * fx[dd.cur];
+    const isInternal = (dd: Debt) => dd.counterparty === "ashton" || dd.counterparty === "partner";
+    const debtA = debts.filter(dd => dd.owner === "ashton").reduce((s, dd) => s + eurBal(dd), 0);
+    const debtM = debts.filter(dd => dd.owner === "partner").reduce((s, dd) => s + eurBal(dd), 0);
+    // Claims = money the OTHER partner owes this person via an internal debt.
+    const debtAClaim = debts.filter(dd => dd.owner === "partner" && dd.counterparty === "ashton").reduce((s, dd) => s + eurBal(dd), 0);
+    const debtMClaim = debts.filter(dd => dd.owner === "ashton" && dd.counterparty === "partner").reduce((s, dd) => s + eurBal(dd), 0);
+    const externalDebt = debts.filter(dd => !isInternal(dd)).reduce((s, dd) => s + eurBal(dd), 0);
+    const totalDebt = debts.reduce((s, dd) => s + eurBal(dd), 0);
     const iouIncoming = ious.filter(i => i.direction === "incoming").reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
     const iouOutgoing = ious.filter(i => i.direction === "outgoing").reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
     const iouNet = iouIncoming - iouOutgoing;
-    const netWorth = totalAssets - totalDebt + iouNet;
-    const netWorthA = personalAssetsA + businessAssets - debtA + iouNet;
-    const netWorthM = personalAssetsM - debtM;
+    // Household net worth only deducts external debts — inter-partner debts cancel.
+    const netWorth = totalAssets - externalDebt + iouNet;
+    const netWorthA = personalAssetsA + businessAssets - debtA + debtAClaim + iouNet;
+    const netWorthM = personalAssetsM - debtM + debtMClaim;
 
     const bizCostTotal = bizCosts.reduce((s, c) => s + c.amt, 0);
     const bizNetFinal = bizRevenue - bizCostTotal;
@@ -186,7 +205,9 @@ export default function LedgerPage() {
       hhBurn, hhIncome, hhSaving,
       personalAssets, personalAssetsA, personalAssetsM, businessAssets,
       liquidAssets, liquidA, liquidM, brokerageAssets, pensionAssets,
-      totalAssets, totalDebt, debtA, debtM, netWorth, netWorthA, netWorthM,
+      totalAssets, totalDebt, externalDebt,
+      debtA, debtM, debtAClaim, debtMClaim,
+      netWorth, netWorthA, netWorthM,
       bizCostTotal, bizNet: bizNetFinal,
       iouIncoming, iouOutgoing, iouNet,
     };
@@ -271,7 +292,7 @@ export default function LedgerPage() {
           <div className="footer-note">
             &ldquo;Annual income twenty pounds, annual expenditure nineteen nineteen and six, result happiness.&rdquo;
             <div className="smallcaps mt-sm">— Mr. Micawber</div>
-            <SyncBadge status={syncStatus} lastSaved={lastSaved} />
+            <SyncBadge status={syncStatus} lastSaved={lastSaved} onRefresh={reload} />
           </div>
         </aside>
 

--- a/app/pages/ledger/data.ts
+++ b/app/pages/ledger/data.ts
@@ -196,14 +196,24 @@ export const ASSETS: Asset[] = [
   { id: "varma_pension", label: "TyEL pension (est.)",  type: "pension",   scope: "personal", owner: "partner", cur: "EUR", bal: 14000.00, apy: null },
 ];
 
-export interface Debt { id: string; label: string; owner: AssetOwner; bal: number; cur: string; rate: number; }
+export type DebtCounterparty = "external" | "ashton" | "partner";
+
+export interface Debt {
+  id: string;
+  label: string;
+  owner: AssetOwner;
+  counterparty?: DebtCounterparty;
+  bal: number;
+  cur: string;
+  rate: number;
+}
 
 export const DEBTS: Debt[] = [
-  { id: "osap",       label: "Canada-Ontario Student Loan (OSAP)", owner: "ashton",  bal:  9900.00, cur: "CAD", rate: 0.050 },
-  { id: "duo",        label: "DUO student loan",                   owner: "ashton",  bal:  5000.00, cur: "EUR", rate: 0.050 },
-  { id: "biz_loan",   label: "Business Loan",                      owner: "ashton",  bal:  2000.00, cur: "EUR", rate: 0.000 },
-  { id: "maria_duo",  label: "DUO (Maria)",                        owner: "partner", bal:  1800.00, cur: "EUR", rate: 0.028 },
-  { id: "maria_fi",   label: "Kela student loan",                  owner: "partner", bal: 12400.00, cur: "EUR", rate: 0.019 },
+  { id: "osap",       label: "Canada-Ontario Student Loan (OSAP)", owner: "ashton",  counterparty: "external", bal:  9900.00, cur: "CAD", rate: 0.050 },
+  { id: "duo",        label: "DUO student loan",                   owner: "ashton",  counterparty: "external", bal:  5000.00, cur: "EUR", rate: 0.050 },
+  { id: "biz_loan",   label: "Business Loan",                      owner: "ashton",  counterparty: "external", bal:  2000.00, cur: "EUR", rate: 0.000 },
+  { id: "maria_duo",  label: "DUO (Maria)",                        owner: "partner", counterparty: "external", bal:  1800.00, cur: "EUR", rate: 0.028 },
+  { id: "maria_fi",   label: "Kela student loan",                  owner: "partner", counterparty: "external", bal: 12400.00, cur: "EUR", rate: 0.019 },
 ];
 
 export interface IouEntry { d: string; label: string; amt: number; kind: "lent" | "borrowed" | "repaid" | "adjust"; }

--- a/app/pages/ledger/screens/Dashboard.tsx
+++ b/app/pages/ledger/screens/Dashboard.tsx
@@ -13,34 +13,38 @@ export function Dashboard({ state, d }: { state: LedgerState; d: Derived }) {
 
   // Joint pot uses ALL accessible assets (liquid + brokerage + business), not just cash.
   // This matches what Ashton's individual view does (liquidA + businessAssets).
+  const mult = state.amtPeriod === "annual" ? 12 : 1;
+  const periodLabel = state.amtPeriod === "annual" ? "/yr" : "/mo";
+  const claimSub = (claim: number) => claim > 0 ? ` · €${Math.round(claim).toLocaleString()} owed to me` : "";
+
   const heroMap = {
     joint: {
       net: d.netWorth,
       netLabel: "Household net worth",
-      netSub: `€${Math.round(d.totalAssets).toLocaleString()} assets · €${Math.round(d.totalDebt).toLocaleString()} debt · €${Math.round(d.iouNet).toLocaleString()} IOU`,
-      saving: d.hhSaving,
+      netSub: `€${Math.round(d.totalAssets).toLocaleString()} assets · €${Math.round(d.externalDebt).toLocaleString()} debt · €${Math.round(d.iouNet).toLocaleString()} IOU`,
+      saving: d.hhSaving * mult,
       savingLabel: "Household saving",
-      savingSub: `${Math.round(d.hhSaving / d.hhIncome * 100)}% of €${Math.round(d.hhIncome).toLocaleString()} combined income`,
+      savingSub: `${Math.round(d.hhSaving / d.hhIncome * 100)}% of €${Math.round(d.hhIncome * mult).toLocaleString()}${periodLabel} combined income`,
       runwayPot: d.liquidAssets + d.brokerageAssets + d.businessAssets,
       runwayBurn: d.hhBurn,
     },
     ashton: {
       net: d.netWorthA,
       netLabel: "Ashton net worth",
-      netSub: `€${Math.round(d.personalAssetsA + d.businessAssets).toLocaleString()} assets · €${Math.round(d.debtA).toLocaleString()} debt · €${Math.round(d.iouNet).toLocaleString()} IOU`,
-      saving: d.aIncome - d.aBurn,
+      netSub: `€${Math.round(d.personalAssetsA + d.businessAssets).toLocaleString()} assets · €${Math.round(d.debtA).toLocaleString()} debt · €${Math.round(d.iouNet).toLocaleString()} IOU${claimSub(d.debtAClaim)}`,
+      saving: (d.aIncome - d.aBurn) * mult,
       savingLabel: "Ashton saving",
-      savingSub: `€${Math.round(d.aIncome).toLocaleString()} in · €${Math.round(d.aBurn).toLocaleString()} out (€${Math.round(d.aPersonal).toLocaleString()} personal + €${Math.round(d.jointTotal * d.aShare).toLocaleString()} joint share)`,
+      savingSub: `€${Math.round(d.aIncome * mult).toLocaleString()}${periodLabel} in · €${Math.round(d.aBurn * mult).toLocaleString()}${periodLabel} out (€${Math.round(d.aPersonal * mult).toLocaleString()} personal + €${Math.round(d.jointTotal * d.aShare * mult).toLocaleString()} joint share)`,
       runwayPot: d.liquidA + d.businessAssets,
       runwayBurn: d.aBurn,
     },
     partner: {
       net: d.netWorthM,
       netLabel: "Maria net worth",
-      netSub: `€${Math.round(d.personalAssetsM).toLocaleString()} assets · €${Math.round(d.debtM).toLocaleString()} debt`,
-      saving: d.mIncome - d.mBurn,
+      netSub: `€${Math.round(d.personalAssetsM).toLocaleString()} assets · €${Math.round(d.debtM).toLocaleString()} debt${claimSub(d.debtMClaim)}`,
+      saving: (d.mIncome - d.mBurn) * mult,
       savingLabel: "Maria saving",
-      savingSub: `€${Math.round(d.mIncome).toLocaleString()} in · €${Math.round(d.mBurn).toLocaleString()} out (€${Math.round(d.mPersonal).toLocaleString()} personal + €${Math.round(d.jointTotal * d.mShare).toLocaleString()} joint share)`,
+      savingSub: `€${Math.round(d.mIncome * mult).toLocaleString()}${periodLabel} in · €${Math.round(d.mBurn * mult).toLocaleString()}${periodLabel} out (€${Math.round(d.mPersonal * mult).toLocaleString()} personal + €${Math.round(d.jointTotal * d.mShare * mult).toLocaleString()} joint share)`,
       runwayPot: d.liquidM,
       runwayBurn: d.mBurn,
     },
@@ -89,10 +93,10 @@ export function Dashboard({ state, d }: { state: LedgerState; d: Derived }) {
         </div>
 
         <div className="grid g-2">
-          <Panel title="This month" meta={dashView === "joint" ? "household flow" : `${dashView === "ashton" ? "Ashton" : "Maria"} flow`}>
-            {dashView === "joint" ? <JointTable d={d} state={state} /> :
-              dashView === "ashton" ? <PersonTable who="ashton" d={d} /> :
-                <PersonTable who="partner" d={d} />}
+          <Panel title={state.amtPeriod === "annual" ? "This year" : "This month"} meta={dashView === "joint" ? "household flow" : `${dashView === "ashton" ? "Ashton" : "Maria"} flow`}>
+            {dashView === "joint" ? <JointTable d={d} state={state} mult={mult} periodLabel={periodLabel} /> :
+              dashView === "ashton" ? <PersonTable who="ashton" d={d} mult={mult} periodLabel={periodLabel} /> :
+                <PersonTable who="partner" d={d} mult={mult} periodLabel={periodLabel} />}
           </Panel>
 
           <CategoryComparison state={state} d={d} />
@@ -107,49 +111,51 @@ export function Dashboard({ state, d }: { state: LedgerState; d: Derived }) {
   );
 }
 
-function JointTable({ d, state }: { d: Derived; state: LedgerState }) {
+function JointTable({ d, state, mult, periodLabel }: { d: Derived; state: LedgerState; mult: number; periodLabel: string }) {
   const b = deriveBiz(
     { monthlyRevenue: state.bizRevenue, costs: state.bizCosts, grossSalary: BUSINESS.grossSalary, dividendMonthly: state.income.ashton.dividend },
     state.tax,
   );
+  const m = (n: number) => `€${Math.round(n * mult).toLocaleString()}`;
   return (
     <table className="table">
       <tbody>
-        <tr className="subtotal"><td colSpan={2} style={{ paddingBottom: 2 }}>Business (Ashton's Oy)</td></tr>
-        <tr><td className="italic" style={{ paddingLeft: 14 }}>Revenue</td><td className="num">€{Math.round(state.bizRevenue).toLocaleString()}</td></tr>
-        <tr><td className="italic" style={{ paddingLeft: 14 }}>Operating costs</td><td className="num neg">−€{Math.round(d.bizCostTotal).toLocaleString()}</td></tr>
-        <tr><td className="italic" style={{ paddingLeft: 14 }}>→ Salary + dividend to Ashton</td><td className="num">€{Math.round(b.netSalary + b.dividendNet).toLocaleString()}</td></tr>
-        <tr><td className="italic" style={{ paddingLeft: 14 }}>→ Retained in Oy</td><td className="num">€{Math.round(b.retained).toLocaleString()}</td></tr>
+        <tr className="subtotal"><td colSpan={2} style={{ paddingBottom: 2 }}>Business (Ashton's Oy) · {periodLabel.replace("/", "per ")}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>Revenue</td><td className="num">{m(state.bizRevenue)}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>Operating costs</td><td className="num neg">−{m(d.bizCostTotal)}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>→ Salary + dividend to Ashton</td><td className="num">{m(b.netSalary + b.dividendNet)}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14 }}>→ Retained in Oy</td><td className="num">{m(b.retained)}</td></tr>
         <tr className="subtotal"><td colSpan={2} style={{ paddingBottom: 2, paddingTop: 8 }}>Household cashflow</td></tr>
-        <tr><td><Who who="ashton" label="Ashton income" /></td><td className="num">€{Math.round(d.aIncome).toLocaleString()}</td></tr>
-        <tr><td className="italic" style={{ paddingLeft: 14, color: "var(--ink-3)" }}>Business retained in Oy</td><td className="num" style={{ color: "var(--ink-3)" }}>€{Math.round(b.retained).toLocaleString()}</td></tr>
-        <tr><td><Who who="partner" label="Maria income" /></td><td className="num">€{Math.round(d.mIncome).toLocaleString()}</td></tr>
-        <tr className="subtotal"><td>Combined income (incl. retained)</td><td className="num">€{Math.round(d.hhIncome + b.retained).toLocaleString()}</td></tr>
-        <tr><td>Joint expenses</td><td className="num neg">−€{Math.round(d.jointTotal).toLocaleString()}</td></tr>
-        <tr><td>Ashton personal</td><td className="num neg">−€{Math.round(d.aPersonal).toLocaleString()}</td></tr>
-        <tr><td>Maria personal</td><td className="num neg">−€{Math.round(d.mPersonal).toLocaleString()}</td></tr>
-        <tr className="total"><td>Net monthly saving</td><td className={`num ${d.hhSaving > 0 ? "pos" : "neg"}`}>€{Math.round(d.hhSaving).toLocaleString()}</td></tr>
+        <tr><td><Who who="ashton" label="Ashton income" /></td><td className="num">{m(d.aIncome)}</td></tr>
+        <tr><td className="italic" style={{ paddingLeft: 14, color: "var(--ink-3)" }}>Business retained in Oy</td><td className="num" style={{ color: "var(--ink-3)" }}>{m(b.retained)}</td></tr>
+        <tr><td><Who who="partner" label="Maria income" /></td><td className="num">{m(d.mIncome)}</td></tr>
+        <tr className="subtotal"><td>Combined income (incl. retained)</td><td className="num">{m(d.hhIncome + b.retained)}</td></tr>
+        <tr><td>Joint expenses</td><td className="num neg">−{m(d.jointTotal)}</td></tr>
+        <tr><td>Ashton personal</td><td className="num neg">−{m(d.aPersonal)}</td></tr>
+        <tr><td>Maria personal</td><td className="num neg">−{m(d.mPersonal)}</td></tr>
+        <tr className="total"><td>Net saving ({periodLabel.replace("/", "")})</td><td className={`num ${d.hhSaving > 0 ? "pos" : "neg"}`}>{m(d.hhSaving)}</td></tr>
       </tbody>
     </table>
   );
 }
 
-function PersonTable({ who, d }: { who: "ashton" | "partner"; d: Derived }) {
+function PersonTable({ who, d, mult, periodLabel }: { who: "ashton" | "partner"; d: Derived; mult: number; periodLabel: string }) {
   const A = who === "ashton";
   const income = A ? d.aIncome : d.mIncome;
   const personal = A ? d.aPersonal : d.mPersonal;
   const jointShare = d.jointTotal * (A ? d.aShare : d.mShare);
   const net = income - personal - jointShare;
+  const m = (n: number) => `€${Math.round(n * mult).toLocaleString()}`;
   return (
     <table className="table">
       <tbody>
-        <tr><td>Take-home income</td><td className="num">€{Math.round(income).toLocaleString()}</td></tr>
+        <tr><td>Take-home income ({periodLabel.replace("/", "")})</td><td className="num">{m(income)}</td></tr>
         <tr><td>Share of joint ({((A ? d.aShare : d.mShare) * 100) | 0}%)</td>
-          <td className="num neg">−€{Math.round(jointShare).toLocaleString()}</td></tr>
+          <td className="num neg">−{m(jointShare)}</td></tr>
         <tr><td>Personal spending</td>
-          <td className="num neg">−€{Math.round(personal).toLocaleString()}</td></tr>
+          <td className="num neg">−{m(personal)}</td></tr>
         <tr className="total"><td>Surplus</td>
-          <td className={`num ${net >= 0 ? "pos" : "neg"}`}>€{Math.round(net).toLocaleString()}</td></tr>
+          <td className={`num ${net >= 0 ? "pos" : "neg"}`}>{m(net)}</td></tr>
       </tbody>
     </table>
   );
@@ -199,8 +205,14 @@ function AssetsPanel({ dashView, d, state }: { dashView: "joint" | "ashton" | "p
         <hr className="rule" style={{ margin: "4px 0" }} />
         <div className="flex-between italic" style={{ color: "var(--crimson)" }}>
           <span>Debts</span>
-          <span className="mono">−€{Math.round(dashView === "ashton" ? d.debtA : d.totalDebt).toLocaleString()}</span>
+          <span className="mono">−€{Math.round(dashView === "ashton" ? d.debtA : d.externalDebt).toLocaleString()}</span>
         </div>
+        {dashView === "ashton" && d.debtAClaim > 0 && (
+          <div className="flex-between italic" style={{ color: "var(--moss)" }}>
+            <span>Owed to me (from Maria)</span>
+            <span className="mono">+€{Math.round(d.debtAClaim).toLocaleString()}</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/pages/ledger/screens/Flow.tsx
+++ b/app/pages/ledger/screens/Flow.tsx
@@ -12,15 +12,21 @@ export function Flow({ state, d }: { state: LedgerState; d: Derived }) {
   });
   useEffect(() => { localStorage.setItem("ledger.flowByCat", byCategory ? "1" : "0"); }, [byCategory]);
 
+  const mult = state.amtPeriod === "annual" ? 12 : 1;
+  const periodLabel = state.amtPeriod === "annual" ? "/yr" : "/mo";
+
   const biz = {
     monthlyRevenue: bizRevenue, costs: bizCosts,
     grossSalary: BUSINESS.grossSalary, dividendMonthly: state.income.ashton.dividend,
   };
   const b = deriveBiz(biz, tax);
 
-  const mGross = state.income.partner.gross || state.income.partner.total;
-  const mTax = mGross * tax.mariaTaxRate;
-  const mNet = mGross - mTax;
+  // Maria's net take-home is the source of truth; gross is re-derived so Flow always
+  // reflects current salary + tax-rate state (previously a stale partner.gross field
+  // made Dashboard / Flow numbers diverge from the salary the user just typed).
+  const mNet = state.income.partner.salary || 0;
+  const mGross = tax.mariaTaxRate < 1 ? mNet / (1 - tax.mariaTaxRate) : mNet;
+  const mTax = mGross - mNet;
 
   const ashtonNet = b.netSalary + b.dividendNet;
   const jointTotal = d.jointTotal;
@@ -32,15 +38,16 @@ export function Flow({ state, d }: { state: LedgerState; d: Derived }) {
   const [fullscreen, setFullscreen] = useState(false);
 
   const svgProps: FullFlowProps = {
-    bizRevenue, bizCostTotal: b.opCosts, grossSalary: BUSINESS.grossSalary,
-    salaryTax: b.salaryTax, netSalary: b.netSalary,
-    preTaxProfit: b.preTaxProfit, corpTax: b.corpTax, afterCorp: b.afterCorp,
-    dividendGross: b.dividendGross, dividendTax: b.dividendTax, dividendNet: b.dividendNet,
-    retained: b.retained, ashtonNet,
-    mGross, mTax, mNet,
-    aJointShare, mJointShare,
-    aPersonal: d.aPersonal, mPersonal: d.mPersonal, aLeftover, mLeftover,
-    jointTotal, byCategory,
+    bizRevenue: bizRevenue * mult, bizCostTotal: b.opCosts * mult, grossSalary: BUSINESS.grossSalary * mult,
+    salaryTax: b.salaryTax * mult, netSalary: b.netSalary * mult,
+    preTaxProfit: b.preTaxProfit * mult, corpTax: b.corpTax * mult, afterCorp: b.afterCorp * mult,
+    dividendGross: b.dividendGross * mult, dividendTax: b.dividendTax * mult, dividendNet: b.dividendNet * mult,
+    retained: b.retained * mult, ashtonNet: ashtonNet * mult,
+    mGross: mGross * mult, mTax: mTax * mult, mNet: mNet * mult,
+    aJointShare: aJointShare * mult, mJointShare: mJointShare * mult,
+    aPersonal: d.aPersonal * mult, mPersonal: d.mPersonal * mult,
+    aLeftover: aLeftover * mult, mLeftover: mLeftover * mult,
+    jointTotal: jointTotal * mult, byCategory,
     joint: state.joint, ashtonP: state.ashtonP, mariaP: state.mariaP,
     aShare: d.aShare, mShare: d.mShare,
   };
@@ -51,8 +58,8 @@ export function Flow({ state, d }: { state: LedgerState; d: Derived }) {
         dek="From business revenue through three tax gates (salary, corporate, dividend) to the things the money actually does." />
 
       <div className="content">
-        <Panel title="Monthly cashflow — April"
-          meta={`Biz €${Math.round(bizRevenue).toLocaleString()} in · Ashton net €${Math.round(ashtonNet).toLocaleString()} · Maria net €${Math.round(mNet).toLocaleString()}`}
+        <Panel title={`${state.amtPeriod === "annual" ? "Yearly" : "Monthly"} cashflow — April`}
+          meta={`Biz €${Math.round(bizRevenue * mult).toLocaleString()}${periodLabel} in · Ashton net €${Math.round(ashtonNet * mult).toLocaleString()}${periodLabel} · Maria net €${Math.round(mNet * mult).toLocaleString()}${periodLabel}`}
           action={
             <button className="btn" style={{ padding: "3px 10px", fontSize: 9 }} onClick={() => setFullscreen(true)}>
               ⤢ Fullscreen
@@ -78,48 +85,48 @@ export function Flow({ state, d }: { state: LedgerState; d: Derived }) {
         )}
 
         <div className="grid g-2">
-          <Panel title="Business — Ashton's Oy" meta={`€${Math.round(bizRevenue).toLocaleString()}/mo in`}>
+          <Panel title="Business — Ashton's Oy" meta={`€${Math.round(bizRevenue * mult).toLocaleString()}${periodLabel} in`}>
             <table className="table">
               <tbody>
-                <tr><td>Gross revenue</td><td className="num">€{bizRevenue.toLocaleString()}</td></tr>
-                <tr><td className="italic">Operating costs</td><td className="num neg">−€{Math.round(b.opCosts).toLocaleString()}</td></tr>
-                <tr><td className="italic">Gross salary booked to Ashton</td><td className="num neg">−€{Math.round(BUSINESS.grossSalary).toLocaleString()}</td></tr>
-                <tr><td className="italic" style={{ paddingLeft: 20 }}>→ Salary tax ({(tax.salaryTaxRate * 100).toFixed(1)}%) to state</td><td className="num neg">−€{Math.round(b.salaryTax).toLocaleString()}</td></tr>
-                <tr><td className="italic" style={{ paddingLeft: 20 }}>→ Net salary to Ashton</td><td className="num">€{Math.round(b.netSalary).toLocaleString()}</td></tr>
-                <tr className="subtotal"><td>Pre-tax profit</td><td className="num">€{Math.round(b.preTaxProfit).toLocaleString()}</td></tr>
-                <tr><td>Corporate tax ({(tax.corpTaxRate * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(b.corpTax).toLocaleString()}</td></tr>
-                <tr className="subtotal"><td>After-tax profit</td><td className="num">€{Math.round(b.afterCorp).toLocaleString()}</td></tr>
-                <tr><td>Dividend declared</td><td className="num neg">−€{Math.round(b.dividendGross).toLocaleString()}</td></tr>
-                <tr className="total"><td>Retained in Oy</td><td className={`num ${b.retained >= 0 ? "pos" : "neg"}`}>€{Math.round(b.retained).toLocaleString()}</td></tr>
+                <tr><td>Gross revenue</td><td className="num">€{Math.round(bizRevenue * mult).toLocaleString()}</td></tr>
+                <tr><td className="italic">Operating costs</td><td className="num neg">−€{Math.round(b.opCosts * mult).toLocaleString()}</td></tr>
+                <tr><td className="italic">Gross salary booked to Ashton</td><td className="num neg">−€{Math.round(BUSINESS.grossSalary * mult).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>→ Salary tax ({(tax.salaryTaxRate * 100).toFixed(1)}%) to state</td><td className="num neg">−€{Math.round(b.salaryTax * mult).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>→ Net salary to Ashton</td><td className="num">€{Math.round(b.netSalary * mult).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>Pre-tax profit</td><td className="num">€{Math.round(b.preTaxProfit * mult).toLocaleString()}</td></tr>
+                <tr><td>Corporate tax ({(tax.corpTaxRate * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(b.corpTax * mult).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>After-tax profit</td><td className="num">€{Math.round(b.afterCorp * mult).toLocaleString()}</td></tr>
+                <tr><td>Dividend declared</td><td className="num neg">−€{Math.round(b.dividendGross * mult).toLocaleString()}</td></tr>
+                <tr className="total"><td>Retained in Oy</td><td className={`num ${b.retained >= 0 ? "pos" : "neg"}`}>€{Math.round(b.retained * mult).toLocaleString()}</td></tr>
               </tbody>
             </table>
           </Panel>
 
-          <Panel title="Ashton — take-home (two streams)" meta={`€${Math.round(ashtonNet).toLocaleString()}/mo`}>
+          <Panel title="Ashton — take-home (two streams)" meta={`€${Math.round(ashtonNet * mult).toLocaleString()}${periodLabel}`}>
             <table className="table">
               <tbody>
-                <tr><td>Net salary (after {(tax.salaryTaxRate * 100).toFixed(1)}% withholding)</td><td className="num">€{Math.round(b.netSalary).toLocaleString()}</td></tr>
-                <tr><td>Dividend declared</td><td className="num">€{Math.round(b.dividendGross).toLocaleString()}</td></tr>
-                <tr><td className="italic" style={{ paddingLeft: 20 }}>− dividend tax ({(tax.dividendTaxRate * 100).toFixed(1)}%)</td><td className="num neg">−€{Math.round(b.dividendTax).toLocaleString()}</td></tr>
-                <tr><td className="italic" style={{ paddingLeft: 20 }}>= dividend net</td><td className="num">€{Math.round(b.dividendNet).toLocaleString()}</td></tr>
-                <tr className="subtotal"><td>Spendable</td><td className="num">€{Math.round(ashtonNet).toLocaleString()}</td></tr>
-                <tr><td>Share of joint ({(d.aShare * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(aJointShare).toLocaleString()}</td></tr>
-                <tr><td>Personal spend</td><td className="num neg">−€{Math.round(d.aPersonal).toLocaleString()}</td></tr>
-                <tr className="total"><td>Surplus</td><td className={`num ${aLeftover >= 0 ? "pos" : "neg"}`}>€{Math.round(aLeftover).toLocaleString()}</td></tr>
+                <tr><td>Net salary (after {(tax.salaryTaxRate * 100).toFixed(1)}% withholding)</td><td className="num">€{Math.round(b.netSalary * mult).toLocaleString()}</td></tr>
+                <tr><td>Dividend declared</td><td className="num">€{Math.round(b.dividendGross * mult).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>− dividend tax ({(tax.dividendTaxRate * 100).toFixed(1)}%)</td><td className="num neg">−€{Math.round(b.dividendTax * mult).toLocaleString()}</td></tr>
+                <tr><td className="italic" style={{ paddingLeft: 20 }}>= dividend net</td><td className="num">€{Math.round(b.dividendNet * mult).toLocaleString()}</td></tr>
+                <tr className="subtotal"><td>Spendable</td><td className="num">€{Math.round(ashtonNet * mult).toLocaleString()}</td></tr>
+                <tr><td>Share of joint ({(d.aShare * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(aJointShare * mult).toLocaleString()}</td></tr>
+                <tr><td>Personal spend</td><td className="num neg">−€{Math.round(d.aPersonal * mult).toLocaleString()}</td></tr>
+                <tr className="total"><td>Surplus</td><td className={`num ${aLeftover >= 0 ? "pos" : "neg"}`}>€{Math.round(aLeftover * mult).toLocaleString()}</td></tr>
               </tbody>
             </table>
           </Panel>
         </div>
 
-        <Panel title="Maria — salary → spendable" meta={`€${Math.round(mGross).toLocaleString()}/mo gross`}>
+        <Panel title="Maria — salary → spendable" meta={`€${Math.round(mGross * mult).toLocaleString()}${periodLabel} gross`}>
           <table className="table">
             <tbody>
-              <tr><td>Gross salary</td><td className="num">€{mGross.toLocaleString()}</td></tr>
-              <tr><td className="italic">Income tax + social contributions ({(tax.mariaTaxRate * 100).toFixed(1)}%)</td><td className="num neg">−€{Math.round(mTax).toLocaleString()}</td></tr>
-              <tr className="subtotal"><td>Net take-home</td><td className="num">€{Math.round(mNet).toLocaleString()}</td></tr>
-              <tr><td>Share of joint ({(d.mShare * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(mJointShare).toLocaleString()}</td></tr>
-              <tr><td>Personal spend</td><td className="num neg">−€{Math.round(d.mPersonal).toLocaleString()}</td></tr>
-              <tr className="total"><td>Surplus</td><td className={`num ${mLeftover >= 0 ? "pos" : "neg"}`}>€{Math.round(mLeftover).toLocaleString()}</td></tr>
+              <tr><td>Gross salary</td><td className="num">€{Math.round(mGross * mult).toLocaleString()}</td></tr>
+              <tr><td className="italic">Income tax + social contributions ({(tax.mariaTaxRate * 100).toFixed(1)}%)</td><td className="num neg">−€{Math.round(mTax * mult).toLocaleString()}</td></tr>
+              <tr className="subtotal"><td>Net take-home</td><td className="num">€{Math.round(mNet * mult).toLocaleString()}</td></tr>
+              <tr><td>Share of joint ({(d.mShare * 100).toFixed(0)}%)</td><td className="num neg">−€{Math.round(mJointShare * mult).toLocaleString()}</td></tr>
+              <tr><td>Personal spend</td><td className="num neg">−€{Math.round(d.mPersonal * mult).toLocaleString()}</td></tr>
+              <tr className="total"><td>Surplus</td><td className={`num ${mLeftover >= 0 ? "pos" : "neg"}`}>€{Math.round(mLeftover * mult).toLocaleString()}</td></tr>
             </tbody>
           </table>
         </Panel>
@@ -146,6 +153,8 @@ interface FullFlowProps {
 interface FlowNode { id: string; label: string; value: number; color: string; x: number; y: number; h: number; sources?: Record<string, number>; }
 interface LinkDef { from: string; to: string; value: number; color: string; }
 
+const FLOW_COL_ORDER_KEY = "ledger.flowColOrders";
+
 function FullFlow(props: FullFlowProps) {
   const {
     bizRevenue, bizCostTotal, grossSalary, salaryTax, netSalary,
@@ -157,8 +166,21 @@ function FullFlow(props: FullFlowProps) {
   } = props;
 
   const [hovered, setHovered] = useState<{ from: string; to: string; value: number; color: string; x: number; y: number } | null>(null);
-  // colOrders stores the user-dragged order for each reorderable column key
-  const [colOrders, setColOrders] = useState<Record<string, string[]>>({});
+  // colOrders stores the user-dragged order for each reorderable column key.
+  // Persisted so a drag survives route changes (Flow unmounts when the user switches pages).
+  const [colOrders, setColOrders] = useState<Record<string, string[]>>(() => {
+    if (typeof window === "undefined") return {};
+    try {
+      const raw = localStorage.getItem(FLOW_COL_ORDER_KEY);
+      return raw ? JSON.parse(raw) as Record<string, string[]> : {};
+    } catch {
+      return {};
+    }
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(FLOW_COL_ORDER_KEY, JSON.stringify(colOrders));
+  }, [colOrders]);
   const [dragging, setDragging] = useState<{ colKey: string; nodeId: string } | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
 

--- a/app/pages/ledger/screens/Inputs.tsx
+++ b/app/pages/ledger/screens/Inputs.tsx
@@ -1,8 +1,26 @@
 import { Fragment, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { Bar, EditableCell, Folio, Panel, Segmented, Smallcaps, Stat, Who } from "../primitives.js";
 import { BUSINESS, CATEGORIES, SETTINGS, deriveBiz, fmt, fx } from "../data.js";
 import type { Derived, LedgerState } from "../state.js";
-import type { Iou, IouEntry, SplitMode, Asset, Debt } from "../data.js";
+import type { CategoryKey, Iou, IouEntry, SplitMode, Asset, AssetOwner, Debt } from "../data.js";
+
+const CATEGORY_OPTIONS: { value: CategoryKey; label: string }[] =
+  Object.entries(CATEGORIES).map(([k, v]) => ({ value: k as CategoryKey, label: v.label }));
+
+function CategorySelect({ value, onChange }: { value?: string; onChange: (v: string) => void }) {
+  return (
+    <select
+      value={value || "other"}
+      onChange={e => onChange(e.target.value)}
+      style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10, letterSpacing: "0.08em", textTransform: "uppercase", cursor: "pointer" }}
+    >
+      {CATEGORY_OPTIONS.map(o => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  );
+}
 
 type InputsSection = "income" | "joint" | "personal" | "business" | "tax" | "assets" | "ious" | "split";
 
@@ -58,16 +76,19 @@ function IncomeSection({ state }: { state: LedgerState }) {
 
   const update = (person: "ashton" | "partner", key: string, v: number) => {
     setIncome(i => {
-      const next = { ...i, [person]: { ...i[person], [key]: v } };
-      next.ashton.total = (next.ashton.salary || 0) + (next.ashton.dividend || 0);
-      next.partner.total = next.partner.salary || 0;
-      return next;
+      const updatedPerson = { ...i[person], [key]: v };
+      const merged = { ...i, [person]: updatedPerson };
+      return {
+        ashton: { ...merged.ashton, total: (merged.ashton.salary || 0) + (merged.ashton.dividend || 0) },
+        partner: { ...merged.partner, total: merged.partner.salary || 0 },
+      };
     });
   };
 
   const applyAshtonGross = (gross: number) => {
     const netSalary = gross * (1 - tax.salaryTaxRate);
     setAshtonGrossDraft(gross);
+    update("ashton", "gross", gross);
     update("ashton", "salary", Math.round(netSalary * 100) / 100);
   };
 
@@ -168,11 +189,12 @@ function JointSection({ state }: { state: LedgerState }) {
   const update = (id: string, v: number) => setJoint(js => js.map(j => j.id === id ? { ...j, amt: v } : j));
   const add = () => setJoint(js => [...js, { id: `c${Date.now()}`, label: "New item", amt: 0, cat: "other" }]);
   const updateLabel = (id: string, v: string) => setJoint(js => js.map(j => j.id === id ? { ...j, label: v } : j));
+  const updateCat = (id: string, v: string) => setJoint(js => js.map(j => j.id === id ? { ...j, cat: v } : j));
   const remove = (id: string) => setJoint(js => js.filter(j => j.id !== id));
 
   return (
     <Panel title="Joint expenses" meta={`${joint.length} items · €${Math.round(total).toLocaleString()}/mo`}>
-      <table className="table">
+      <div className="table-wrap"><table className="table">
         <thead>
           <tr><th>Item</th><th>Category</th><th className="num">Monthly</th><th className="num">Yearly</th><th></th></tr>
         </thead>
@@ -184,7 +206,7 @@ function JointSection({ state }: { state: LedgerState }) {
                   onChange={e => updateLabel(j.id!, e.target.value)}
                   style={{ minWidth: 200 }} />
               </td>
-              <td><span className="pill">{j.cat}</span></td>
+              <td><CategorySelect value={j.cat} onChange={v => updateCat(j.id!, v)} /></td>
               <EditableCell value={j.amt} onChange={v => update(j.id!, v)} prefix="€" />
               <td className="num italic" style={{ color: "var(--ink-3)" }}>€{(j.amt * 12).toLocaleString()}</td>
               <td><button onClick={() => remove(j.id!)} style={{ color: "var(--ink-3)" }}>×</button></td>
@@ -197,7 +219,7 @@ function JointSection({ state }: { state: LedgerState }) {
             <td></td>
           </tr>
         </tbody>
-      </table>
+      </table></div>
       <button className="btn mt-md" onClick={add}>+ Add joint expense</button>
     </Panel>
   );
@@ -217,11 +239,15 @@ function PersonalList({ title, list, setList }: { title: string; list: LedgerSta
   const total = list.reduce((s, x) => s + x.amt, 0);
   const update = (i: number, v: number) => setList(xs => xs.map((x, j) => j === i ? { ...x, amt: v } : x));
   const updateLabel = (i: number, v: string) => setList(xs => xs.map((x, j) => j === i ? { ...x, label: v } : x));
-  const add = () => setList(xs => [...xs, { label: "New item", amt: 0 }]);
+  const updateCat = (i: number, v: string) => setList(xs => xs.map((x, j) => j === i ? { ...x, cat: v } : x));
+  const add = () => setList(xs => [...xs, { label: "New item", amt: 0, cat: "other" }]);
   const remove = (i: number) => setList(xs => xs.filter((_, j) => j !== i));
   return (
     <Panel title={title} meta={`${list.length} · €${Math.round(total).toLocaleString()}/mo`}>
-      <table className="table">
+      <div className="table-wrap"><table className="table">
+        <thead>
+          <tr><th>Item</th><th>Category</th><th className="num">Monthly</th><th></th></tr>
+        </thead>
         <tbody>
           {list.map((it, i) => (
             <tr key={i}>
@@ -229,17 +255,18 @@ function PersonalList({ title, list, setList }: { title: string; list: LedgerSta
                 <input className="cell-input" value={it.label}
                   onChange={e => updateLabel(i, e.target.value)} />
               </td>
+              <td><CategorySelect value={it.cat} onChange={v => updateCat(i, v)} /></td>
               <EditableCell value={it.amt} onChange={v => update(i, v)} prefix="€" />
               <td><button onClick={() => remove(i)} style={{ color: "var(--ink-3)" }}>×</button></td>
             </tr>
           ))}
           <tr className="total">
-            <td>Total</td>
+            <td colSpan={2}>Total</td>
             <td className="num">€{Math.round(total).toLocaleString()}</td>
             <td></td>
           </tr>
         </tbody>
-      </table>
+      </table></div>
       <button className="btn mt-md" onClick={add}>+ Add</button>
     </Panel>
   );
@@ -257,7 +284,7 @@ function BusinessSection({ state }: { state: LedgerState }) {
   return (
     <div className="grid g-2-1">
       <Panel title="Business costs" meta={`${bizCosts.length} · €${Math.round(total).toLocaleString()}/mo`}>
-        <table className="table">
+        <div className="table-wrap"><table className="table">
           <tbody>
             {bizCosts.map((c, i) => (
               <tr key={i}>
@@ -277,7 +304,7 @@ function BusinessSection({ state }: { state: LedgerState }) {
               <td></td>
             </tr>
           </tbody>
-        </table>
+        </table></div>
         <button className="btn mt-md" onClick={add}>+ Add business cost</button>
       </Panel>
       <Panel title="Revenue & summary">
@@ -301,13 +328,17 @@ function AssetsSection({ state }: { state: LedgerState }) {
   const totalDebt = debts.reduce((s, d) => s + d.bal * fx[d.cur], 0);
   const upd = (id: string, v: number) => setAssets(as => as.map(a => a.id === id ? { ...a, bal: v } : a));
   const updLabel = (id: string, v: string) => setAssets(as => as.map(a => a.id === id ? { ...a, label: v } : a));
+  const updOwner = (id: string, owner: AssetOwner) => setAssets(as => as.map(a => a.id === id ? { ...a, owner } : a));
   const rem = (id: string) => setAssets(as => as.filter(a => a.id !== id));
   const add = () => setAssets(as => [...as, { id: `a${Date.now()}`, label: "New account", type: "cash", scope: "personal", owner: "ashton", cur: "EUR", bal: 0, apy: 0 }]);
 
   const updDebt = (id: string, v: number) => setDebts(ds => ds.map(d => d.id === id ? { ...d, bal: v } : d));
   const updDebtLabel = (id: string, v: string) => setDebts(ds => ds.map(d => d.id === id ? { ...d, label: v } : d));
+  const updDebtOwner = (id: string, owner: AssetOwner) => setDebts(ds => ds.map(d => d.id === id ? { ...d, owner } : d));
+  const updDebtCounterparty = (id: string, counterparty: Debt["counterparty"]) =>
+    setDebts(ds => ds.map(d => d.id === id ? { ...d, counterparty } : d));
   const remDebt = (id: string) => setDebts(ds => ds.filter(d => d.id !== id));
-  const addDebt = () => setDebts(ds => [...ds, { id: `d${Date.now()}`, label: "New debt", owner: "ashton", bal: 0, cur: "EUR", rate: 0 }]);
+  const addDebt = () => setDebts(ds => [...ds, { id: `d${Date.now()}`, label: "New debt", owner: "ashton", counterparty: "external", bal: 0, cur: "EUR", rate: 0 }]);
 
   const updateScope = (id: string, scope: Asset["scope"]) => setAssets(as => as.map(a => a.id === id ? { ...a, scope } : a));
   const updateType = (id: string, type: Asset["type"]) => setAssets(as => as.map(a => a.id === id ? { ...a, type } : a));
@@ -316,14 +347,20 @@ function AssetsSection({ state }: { state: LedgerState }) {
   return (
     <>
       <Panel title="Assets" meta={`${assets.length} accounts · €${Math.round(total).toLocaleString()} total`}>
-        <table className="table">
+        <div className="table-wrap"><table className="table">
           <thead>
-            <tr><th>Account</th><th>Scope</th><th>Type</th><th>Cur</th><th className="num">Balance</th><th className="num">EUR</th><th></th></tr>
+            <tr><th>Account</th><th>Owner</th><th>Scope</th><th>Type</th><th>Cur</th><th className="num">Balance</th><th className="num">EUR</th><th></th></tr>
           </thead>
           <tbody>
             {assets.map(a => (
               <tr key={a.id}>
                 <td><input className="cell-input" value={a.label} onChange={e => updLabel(a.id, e.target.value)} /></td>
+                <td>
+                  <select value={a.owner} onChange={e => updOwner(a.id, e.target.value as AssetOwner)} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+                    <option value="ashton">Ashton</option>
+                    <option value="partner">Maria</option>
+                  </select>
+                </td>
                 <td>
                   <select value={a.scope} onChange={e => updateScope(a.id, e.target.value as Asset["scope"])} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
                     <option value="personal">personal</option>
@@ -353,43 +390,145 @@ function AssetsSection({ state }: { state: LedgerState }) {
               </tr>
             ))}
             <tr className="total">
-              <td colSpan={5}>Total</td>
+              <td colSpan={6}>Total</td>
               <td className="num">€{Math.round(total).toLocaleString()}</td>
               <td></td>
             </tr>
           </tbody>
-        </table>
+        </table></div>
         <button className="btn mt-md" onClick={add}>+ Add account</button>
       </Panel>
 
       <Panel title="Debts" meta={`${debts.length} · €${Math.round(totalDebt).toLocaleString()} outstanding`}>
-        <table className="table">
+        <div className="italic mb-md" style={{ fontSize: 12, color: "var(--ink-3)" }}>
+          Choose who owes the debt and to whom. Debts between Ashton and Maria cancel out in the Joint view but show on each individual's net worth.
+        </div>
+        <div className="table-wrap"><table className="table">
           <thead>
-            <tr><th>Debt</th><th>Cur</th><th className="num">Balance</th><th className="num">Rate</th><th className="num">Annual interest</th><th></th></tr>
+            <tr>
+              <th>Debt</th>
+              <th>Owed by</th>
+              <th>Owed to</th>
+              <th>Cur</th>
+              <th className="num">Balance</th>
+              <th className="num">Rate</th>
+              <th className="num">Annual interest</th>
+              <th></th>
+            </tr>
           </thead>
           <tbody>
-            {debts.map(debt => (
-              <tr key={debt.id}>
-                <td><input className="cell-input" value={debt.label} onChange={e => updDebtLabel(debt.id, e.target.value)} /></td>
-                <td className="mono" style={{ fontSize: 10 }}>{debt.cur}</td>
-                <EditableCell value={debt.bal} onChange={v => updDebt(debt.id, v)} prefix={debt.cur === "CAD" ? "C$" : "€"} />
-                <td className="num">{(debt.rate * 100).toFixed(2)}%</td>
-                <td className="num neg">−€{Math.round(debt.bal * fx[debt.cur] * debt.rate).toLocaleString()}</td>
-                <td><button onClick={() => remDebt(debt.id)} style={{ color: "var(--ink-3)" }}>×</button></td>
-              </tr>
-            ))}
+            {debts.map(debt => {
+              const cp = debt.counterparty ?? "external";
+              return (
+                <tr key={debt.id}>
+                  <td><input className="cell-input" value={debt.label} onChange={e => updDebtLabel(debt.id, e.target.value)} /></td>
+                  <td>
+                    <select value={debt.owner} onChange={e => updDebtOwner(debt.id, e.target.value as AssetOwner)} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+                      <option value="ashton">Ashton</option>
+                      <option value="partner">Maria</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select value={cp} onChange={e => updDebtCounterparty(debt.id, e.target.value as Debt["counterparty"])} style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+                      <option value="external">external</option>
+                      <option value="ashton" disabled={debt.owner === "ashton"}>Ashton</option>
+                      <option value="partner" disabled={debt.owner === "partner"}>Maria</option>
+                    </select>
+                  </td>
+                  <td className="mono" style={{ fontSize: 10 }}>{debt.cur}</td>
+                  <EditableCell value={debt.bal} onChange={v => updDebt(debt.id, v)} prefix={debt.cur === "CAD" ? "C$" : "€"} />
+                  <td className="num">{(debt.rate * 100).toFixed(2)}%</td>
+                  <td className="num neg">−€{Math.round(debt.bal * fx[debt.cur] * debt.rate).toLocaleString()}</td>
+                  <td><button onClick={() => remDebt(debt.id)} style={{ color: "var(--ink-3)" }}>×</button></td>
+                </tr>
+              );
+            })}
             <tr className="total">
-              <td colSpan={2}>Total</td>
+              <td colSpan={4}>Total</td>
               <td className="num">€{Math.round(totalDebt).toLocaleString()}</td>
               <td></td>
               <td className="num neg">−€{Math.round(debts.reduce((s, d) => s + d.bal * fx[d.cur] * d.rate, 0)).toLocaleString()}</td>
               <td></td>
             </tr>
           </tbody>
-        </table>
+        </table></div>
         <button className="btn mt-md" onClick={addDebt}>+ Add debt</button>
       </Panel>
     </>
+  );
+}
+
+interface IouRowProps {
+  i: Iou;
+  isOpen: boolean;
+  setOpen: Dispatch<SetStateAction<string | null>>;
+  upd: (id: string, k: keyof Iou, v: unknown) => void;
+  rem: (id: string) => void;
+  addEntry: (id: string, entry: IouEntry) => void;
+}
+
+function IouRow({ i, isOpen, setOpen, upd, rem, addEntry }: IouRowProps) {
+  const outstanding = i.principal - i.paid;
+  const pct = i.principal ? (i.paid / i.principal * 100) : 0;
+  return (
+    <Fragment>
+      <tr>
+        <td>
+          <input className="cell-input" value={i.counterparty}
+            onChange={e => upd(i.id, "counterparty", e.target.value)} />
+          {i.note && <div className="italic" style={{ fontSize: 11, color: "var(--ink-3)" }}>{i.note}</div>}
+        </td>
+        <td>
+          <select value={i.direction} onChange={e => upd(i.id, "direction", e.target.value)}
+            style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
+            <option value="incoming">owes me</option>
+            <option value="outgoing">I owe</option>
+          </select>
+        </td>
+        <td className="mono" style={{ fontSize: 10 }}>{i.cur}</td>
+        <td className="num mono">{fmt(i.principal, i.cur, { decimals: 0 })}</td>
+        <td className="num mono pos">{fmt(i.paid, i.cur, { decimals: 0 })}</td>
+        <td className="num mono" style={{ fontWeight: 700 }}>{fmt(outstanding, i.cur, { decimals: 0 })}</td>
+        <td style={{ width: 120 }}><Bar pct={pct} variant={i.direction === "incoming" ? "moss" : "rust"} /></td>
+        <td className="num mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>{pct.toFixed(0)}%</td>
+        <td>
+          <button onClick={() => setOpen(isOpen ? null : i.id)} className="smallcaps">{isOpen ? "close" : "edit"}</button>
+          {" · "}
+          <button onClick={() => rem(i.id)} style={{ color: "var(--ink-3)" }}>×</button>
+        </td>
+      </tr>
+      {isOpen && (
+        <tr>
+          <td colSpan={9} style={{ background: "var(--paper-2)", padding: 14 }}>
+            <div className="flex-between" style={{ marginBottom: 10 }}>
+              <Smallcaps>Description / note</Smallcaps>
+            </div>
+            <input className="cell-input" value={i.note || ""}
+              placeholder="What is this IOU about? e.g. Rent apartment coverage, cat vet, splitting settlement…"
+              onChange={e => upd(i.id, "note", e.target.value)}
+              style={{ fontStyle: "italic", padding: "6px 8px", marginBottom: 14, border: "1px solid var(--rule-soft)", background: "var(--paper)" }} />
+
+            <Smallcaps>Ledger — {i.counterparty}</Smallcaps>
+            <table className="table mt-sm" style={{ background: "transparent" }}>
+              <thead><tr><th>Date</th><th>Label</th><th>Kind</th><th className="num">Amount ({i.cur})</th></tr></thead>
+              <tbody>
+                {(i.history || []).map((h, idx) => (
+                  <tr key={idx}>
+                    <td className="mono" style={{ fontSize: 10 }}>{h.d}</td>
+                    <td>{h.label}</td>
+                    <td><span className="pill">{h.kind}</span></td>
+                    <td className={`num ${h.kind === "repaid" ? "pos" : ""}`}>
+                      {h.kind === "repaid" ? "+" : ""}{fmt(h.amt, i.cur, { decimals: 2 })}
+                    </td>
+                  </tr>
+                ))}
+                <NewEntryRow onAdd={(entry) => addEntry(i.id, entry)} direction={i.direction} />
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      )}
+    </Fragment>
   );
 }
 
@@ -415,72 +554,6 @@ function IousSection({ state }: { state: LedgerState }) {
   const incSum = incoming.reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
   const outSum = outgoing.reduce((s, i) => s + (i.principal - i.paid) * fx[i.cur], 0);
 
-  const Row = ({ i }: { i: Iou }) => {
-    const outstanding = i.principal - i.paid;
-    const pct = i.principal ? (i.paid / i.principal * 100) : 0;
-    const isOpen = open === i.id;
-    return (
-      <Fragment>
-        <tr>
-          <td>
-            <input className="cell-input" value={i.counterparty}
-              onChange={e => upd(i.id, "counterparty", e.target.value)} />
-            {i.note && <div className="italic" style={{ fontSize: 11, color: "var(--ink-3)" }}>{i.note}</div>}
-          </td>
-          <td>
-            <select value={i.direction} onChange={e => upd(i.id, "direction", e.target.value)}
-              style={{ border: 0, background: "transparent", fontFamily: "var(--mono)", fontSize: 10 }}>
-              <option value="incoming">owes me</option>
-              <option value="outgoing">I owe</option>
-            </select>
-          </td>
-          <td className="mono" style={{ fontSize: 10 }}>{i.cur}</td>
-          <td className="num mono">{fmt(i.principal, i.cur, { decimals: 0 })}</td>
-          <td className="num mono pos">{fmt(i.paid, i.cur, { decimals: 0 })}</td>
-          <td className="num mono" style={{ fontWeight: 700 }}>{fmt(outstanding, i.cur, { decimals: 0 })}</td>
-          <td style={{ width: 120 }}><Bar pct={pct} variant={i.direction === "incoming" ? "moss" : "rust"} /></td>
-          <td className="num mono" style={{ fontSize: 10, color: "var(--ink-3)" }}>{pct.toFixed(0)}%</td>
-          <td>
-            <button onClick={() => setOpen(isOpen ? null : i.id)} className="smallcaps">{isOpen ? "close" : "edit"}</button>
-            {" · "}
-            <button onClick={() => rem(i.id)} style={{ color: "var(--ink-3)" }}>×</button>
-          </td>
-        </tr>
-        {isOpen && (
-          <tr>
-            <td colSpan={9} style={{ background: "var(--paper-2)", padding: 14 }}>
-              <div className="flex-between" style={{ marginBottom: 10 }}>
-                <Smallcaps>Description / note</Smallcaps>
-              </div>
-              <input className="cell-input" value={i.note || ""}
-                placeholder="What is this IOU about? e.g. Rent apartment coverage, cat vet, splitting settlement…"
-                onChange={e => upd(i.id, "note", e.target.value)}
-                style={{ fontStyle: "italic", padding: "6px 8px", marginBottom: 14, border: "1px solid var(--rule-soft)", background: "var(--paper)" }} />
-
-              <Smallcaps>Ledger — {i.counterparty}</Smallcaps>
-              <table className="table mt-sm" style={{ background: "transparent" }}>
-                <thead><tr><th>Date</th><th>Label</th><th>Kind</th><th className="num">Amount ({i.cur})</th></tr></thead>
-                <tbody>
-                  {(i.history || []).map((h, idx) => (
-                    <tr key={idx}>
-                      <td className="mono" style={{ fontSize: 10 }}>{h.d}</td>
-                      <td>{h.label}</td>
-                      <td><span className="pill">{h.kind}</span></td>
-                      <td className={`num ${h.kind === "repaid" ? "pos" : ""}`}>
-                        {h.kind === "repaid" ? "+" : ""}{fmt(h.amt, i.cur, { decimals: 2 })}
-                      </td>
-                    </tr>
-                  ))}
-                  <NewEntryRow onAdd={(entry) => addEntry(i.id, entry)} direction={i.direction} />
-                </tbody>
-              </table>
-            </td>
-          </tr>
-        )}
-      </Fragment>
-    );
-  };
-
   return (
     <Fragment>
       <div className="grid g-3">
@@ -490,7 +563,7 @@ function IousSection({ state }: { state: LedgerState }) {
       </div>
 
       <Panel title="Money owed between people" meta="click a row to see history">
-        <table className="table">
+        <div className="table-wrap"><table className="table">
           <thead>
             <tr>
               <th>Person</th><th>Direction</th><th>Cur</th>
@@ -503,9 +576,12 @@ function IousSection({ state }: { state: LedgerState }) {
             </tr>
           </thead>
           <tbody>
-            {ious.map(i => <Row key={i.id} i={i} />)}
+            {ious.map(i => (
+              <IouRow key={i.id} i={i} isOpen={open === i.id}
+                setOpen={setOpen} upd={upd} rem={rem} addEntry={addEntry} />
+            ))}
           </tbody>
-        </table>
+        </table></div>
         <button className="btn mt-md" onClick={add}>+ Add IOU</button>
       </Panel>
     </Fragment>

--- a/app/pages/ledger/state.ts
+++ b/app/pages/ledger/state.ts
@@ -62,8 +62,11 @@ export interface Derived {
   pensionAssets: number;
   totalAssets: number;
   totalDebt: number;
+  externalDebt: number;
   debtA: number;
   debtM: number;
+  debtAClaim: number;
+  debtMClaim: number;
   netWorth: number;
   netWorthA: number;
   netWorthM: number;

--- a/app/pages/ledger/styles.css
+++ b/app/pages/ledger/styles.css
@@ -322,6 +322,8 @@
 }
 
 /* ------------------------------------------------------------- tables */
+.ledger-root .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.ledger-root .table-wrap .table { min-width: max-content; }
 .ledger-root .table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .ledger-root .table th {
   text-align: left;

--- a/app/pages/ledger/useLedgerSync.ts
+++ b/app/pages/ledger/useLedgerSync.ts
@@ -14,9 +14,16 @@ export function useLedgerSync(
   // Stays true until the initial load resolves — suppresses the save-on-change effect
   const initialising = useRef(true);
   const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+  // Tracks whether a save is queued or in-flight so a focus-refetch never clobbers
+  // a local edit the user just made on this device.
+  const hasPendingSave = useRef(false);
+  const inFlightSave = useRef(false);
+  const onLoadRef = useRef(onLoad);
+  onLoadRef.current = onLoad;
 
   const persist = useCallback(async (data: LedgerStatePayload) => {
     setStatus("saving");
+    inFlightSave.current = true;
     try {
       const res = await apiClient.saveLedgerState({ query: { userId }, body: data });
       if (res.status === 200) {
@@ -28,6 +35,25 @@ export function useLedgerSync(
       }
     } catch {
       setStatus("error");
+    } finally {
+      inFlightSave.current = false;
+      hasPendingSave.current = false;
+    }
+  }, [userId]);
+
+  const reload = useCallback(async () => {
+    // Skip if a local save is pending / running — the server is about to be overwritten
+    // with what this device has anyway, so pulling now would either lose edits or race.
+    if (hasPendingSave.current || inFlightSave.current) return;
+    try {
+      const res = await apiClient.getLedgerState({ query: { userId } });
+      if (res.status === 200 && res.body.state !== null) {
+        onLoadRef.current(res.body.state);
+        setLastSaved(res.body.updatedAt);
+        setStatus("idle");
+      }
+    } catch {
+      // network blip — ignore
     }
   }, [userId]);
 
@@ -40,7 +66,7 @@ export function useLedgerSync(
         if (cancelled) return;
         if (res.status === 200) {
           if (res.body.state !== null) {
-            onLoad(res.body.state);
+            onLoadRef.current(res.body.state);
             setLastSaved(res.body.updatedAt);
             setStatus("idle");
           } else {
@@ -65,10 +91,30 @@ export function useLedgerSync(
   // Debounced auto-save whenever the payload changes after initial load
   useEffect(() => {
     if (initialising.current) return;
+    hasPendingSave.current = true;
     clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => persist(payload), 2000);
     return () => clearTimeout(saveTimer.current);
   }, [payload, persist]);
 
-  return { status, lastSaved };
+  // Pull the latest server state when the tab regains focus / becomes visible again.
+  // This is what makes the ledger stay in sync across desktop + tablet — otherwise
+  // each device keeps whatever was loaded at mount and last-writer-wins on save.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && !initialising.current) reload();
+    };
+    const onFocus = () => {
+      if (!initialising.current) reload();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [reload]);
+
+  return { status, lastSaved, reload };
 }


### PR DESCRIPTION
- Fix IOU row losing focus on keystroke (extract IouRow to module scope)
- Fix income state mutation bug causing stale mIncome across the app
- Add debt counterparty model (external / ashton / partner) so inter-partner debts cancel in joint view but flow correctly to individual net worth
- Add cross-device sync via visibilitychange + focus reload, guarded against clobbering in-flight saves
- Persist Sankey column order to localStorage so it survives navigation
- Add category editing on joint and personal expense rows
- Extend monthly/annual toggle (amtPeriod) to Dashboard and Flow screens
- Add horizontal-scroll wrappers on all wide input tables for mobile